### PR TITLE
Extracts renaming/creation of alchemy_roles column to own migration.

### DIFF
--- a/db/migrate/20131015124700_create_alchemy_users.rb
+++ b/db/migrate/20131015124700_create_alchemy_users.rb
@@ -7,7 +7,6 @@ class CreateAlchemyUsers < ActiveRecord::Migration
       t.string   "login"
       t.string   "email"
       t.string   "gender"
-      t.string   "alchemy_roles",                              default: "member"
       t.string   "language"
       t.string   "encrypted_password",     limit: 128, default: "",       null: false
       t.string   "password_salt",          limit: 128, default: "",       null: false
@@ -30,6 +29,5 @@ class CreateAlchemyUsers < ActiveRecord::Migration
     add_index "alchemy_users", ["email"], name: "index_alchemy_users_on_email", unique: true
     add_index "alchemy_users", ["login"], name: "index_alchemy_users_on_login", unique: true
     add_index "alchemy_users", ["reset_password_token"], name: "index_alchemy_users_on_reset_password_token", unique: true
-    add_index "alchemy_users", ["alchemy_roles"], name: "index_alchemy_users_on_alchemy_roles"
   end
 end

--- a/db/migrate/20131225232042_add_alchemy_roles_to_alchemy_users.rb
+++ b/db/migrate/20131225232042_add_alchemy_roles_to_alchemy_users.rb
@@ -1,0 +1,19 @@
+class AddAlchemyRolesToAlchemyUsers < ActiveRecord::Migration
+  def up
+    # Updating old :roles column (since Alchemy CMS v2.6)
+    if column_exists?(:alchemy_users, :roles)
+      remove_index :alchemy_users, name: "index_alchemy_users_on_roles"
+      rename_column :alchemy_users, :roles, :alchemy_roles
+      change_column :alchemy_users, :alchemy_roles, :string, default: "member"
+    end
+
+    # Creating :alchemy_roles column for new apps.
+    unless column_exists?(:alchemy_users, :alchemy_roles)
+      add_column :alchemy_users, :alchemy_roles, :string, default: "member"
+    end
+
+    unless index_exists?(:alchemy_users, :alchemy_roles, name: "index_alchemy_users_on_alchemy_roles")
+      add_index :alchemy_users, :alchemy_roles, name: "index_alchemy_users_on_alchemy_roles"
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20131018201539_alchemy_two_point_six.alchemy.rb
+++ b/spec/dummy/db/migrate/20131018201539_alchemy_two_point_six.alchemy.rb
@@ -266,37 +266,6 @@ class AlchemyTwoPointSix < ActiveRecord::Migration
     add_index "alchemy_sites", ["host", "public"], :name => "alchemy_sites_public_hosts_idx"
     add_index "alchemy_sites", ["host"], :name => "index_alchemy_sites_on_host"
 
-    create_table "alchemy_users", :force => true do |t|
-      t.string   "firstname"
-      t.string   "lastname"
-      t.string   "login"
-      t.string   "email"
-      t.string   "gender"
-      t.string   "roles",                                 :default => "registered"
-      t.string   "language"
-      t.string   "encrypted_password",     :limit => 128, :default => "",           :null => false
-      t.string   "password_salt",          :limit => 128, :default => "",           :null => false
-      t.integer  "sign_in_count",                         :default => 0,            :null => false
-      t.integer  "failed_attempts",                       :default => 0,            :null => false
-      t.datetime "last_request_at"
-      t.datetime "current_sign_in_at"
-      t.datetime "last_sign_in_at"
-      t.string   "current_sign_in_ip"
-      t.string   "last_sign_in_ip"
-      t.datetime "created_at",                                                      :null => false
-      t.datetime "updated_at",                                                      :null => false
-      t.integer  "creator_id"
-      t.integer  "updater_id"
-      t.text     "cached_tag_list"
-      t.string   "reset_password_token"
-      t.datetime "reset_password_sent_at"
-    end
-
-    add_index "alchemy_users", ["email"], :name => "index_alchemy_users_on_email", :unique => true
-    add_index "alchemy_users", ["login"], :name => "index_alchemy_users_on_login", :unique => true
-    add_index "alchemy_users", ["reset_password_token"], :name => "index_alchemy_users_on_reset_password_token", :unique => true
-    add_index "alchemy_users", ["roles"], :name => "index_alchemy_users_on_roles"
-
     create_table "events", :force => true do |t|
       t.string   "name"
       t.string   "hidden_name"

--- a/spec/dummy/db/migrate/20131018201542_remove_alchemy_users.alchemy.rb
+++ b/spec/dummy/db/migrate/20131018201542_remove_alchemy_users.alchemy.rb
@@ -1,6 +1,0 @@
-# This migration comes from alchemy (originally 20131015125201)
-class RemoveAlchemyUsers < ActiveRecord::Migration
-  def up
-    drop_table :alchemy_users
-  end
-end

--- a/spec/dummy/db/migrate/20131225232042_add_alchemy_roles_to_alchemy_users.rb
+++ b/spec/dummy/db/migrate/20131225232042_add_alchemy_roles_to_alchemy_users.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20131225232042_add_alchemy_roles_to_alchemy_users.rb


### PR DESCRIPTION
When upgrading an app to Alchemy 3.0 it comes with an alchemy_users table. So the first migration of this gem (creation of alchemy_users) will not run. But the existing roles column of the app has to be updated to alchemy_roles anyway. That's the reason why we moved that column changing part to a separate migration and check if we need to rename or add the alchemy_roles column.
