### PR TITLE
Update alchemy-devise.gemspec

### DIFF
--- a/alchemy-devise.gemspec
+++ b/alchemy-devise.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "alchemy_cms", "~> 3.0.0.beta1"
-  s.add_dependency "devise",      "~> 3.0.0"
+  s.add_dependency "devise",      "~> 3.2.3"
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "capybara"


### PR DESCRIPTION
devise 3.0.0 does not have secret_key; 3.2.3 does
