### PR TITLE
Fixes password_reset feature to work with devise 3.

### DIFF
--- a/app/controllers/alchemy/passwords_controller.rb
+++ b/app/controllers/alchemy/passwords_controller.rb
@@ -8,10 +8,6 @@ module Alchemy
 
     layout 'alchemy/login'
 
-    def new
-      build_resource(email: params[:email])
-    end
-
     private
 
     # Override for Devise method

--- a/app/views/alchemy/passwords/new.html.erb
+++ b/app/views/alchemy/passwords/new.html.erb
@@ -13,7 +13,7 @@
       <%= devise_error_messages! %>
     </div>
     <% end %>
-    <%= form_for(:user, :url => password_path, :html => { :method => :post }) do |f| %>
+    <%= form_for(:user, :url => reset_password_path, :html => { :method => :post }) do |f| %>
       <table>
         <tr>
           <td class="label"><%= f.label :email %></td>


### PR DESCRIPTION
The current implementation of the password_reset related methods assumes to use devise v2. But alchemy-devise 1.1 uses devise v3 where the api has changed concerning password_reset.

I think alchemy-devise >= 2.0 also contain these changes.
