### PR TITLE
add registerable to devise modules

### DIFF
--- a/app/models/alchemy/user.rb
+++ b/app/models/alchemy/user.rb
@@ -20,7 +20,8 @@ module Alchemy
       :trackable,
       :validatable,
       :timeoutable,
-      :recoverable
+      :recoverable,
+      :registerable
     ]
     # If the app uses an old encryption it uses the devise-encryptable gem
     # therefore we have to load the devise module


### PR DESCRIPTION
It appears that in a standard application, when I visit `/user/sign_up` I receive the error:

```ruby
NoMethodError - undefined method `new_with_session' for #<Class:0x007fb8c944b428>
```

This PR should fix that.