### PR TITLE
Use main app's secret_key_base as secret_key

### DIFF
--- a/lib/generators/alchemy/devise/install/templates/devise.rb.tt
+++ b/lib/generators/alchemy/devise/install/templates/devise.rb.tt
@@ -4,7 +4,11 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  config.secret_key = <%= SecureRandom.hex(50).inspect %>
+
+  # By default, Devise will use your Application's secret_key_base as its
+  # secret_key. You can override it here by uncommenting the following
+  # line. Remember to keep this file out of source control if you do that.
+  # config.secret_key = <%= SecureRandom.hex(50).inspect %>
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -99,7 +103,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 10
 
   # Setup a pepper to generate the encrypted password.
-  config.pepper = <%= SecureRandom.hex(50).inspect %>
+  # config.pepper = <%= SecureRandom.hex(50).inspect %>
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without


### PR DESCRIPTION
This has three advantages:
 - No secret keys in source control
 - We're mirroring standard Devise behavious
 - We don't break existing Alchemy installations

The Devise.pepper variable is also not set UNLESS there
is an environment variable set. That way, the Devise
initializer can safely be checked in to your git repo.