### PR TITLE
Fix: No double render errors after delivery errors

### DIFF
--- a/spec/requests/admin/users_controller_request_spec.rb
+++ b/spec/requests/admin/users_controller_request_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe Alchemy::Admin::UsersController, type: :request do
+  before do
+    authorize_user create(:alchemy_admin_user)
+  end
+
+  context 'with error happening while sending mail' do
+    before do
+      allow_any_instance_of(Alchemy::Admin::BaseController).
+        to receive(:raise_exception?) { false }
+      allow_any_instance_of(Alchemy::User).
+        to receive(:deliver_welcome_mail) { raise(Net::SMTPAuthenticationError) }
+    end
+
+    context 'on create' do
+      it 'does not raise DoubleRender error' do
+        expect {
+          post admin_users_path, user: attributes_for(:alchemy_user).merge(send_credentials: '1')
+        }.to_not raise_error
+      end
+    end
+
+    context 'on update' do
+      it 'does not raise DoubleRender error' do
+        user =  create(:alchemy_member_user)
+        expect {
+          patch admin_user_path(user), user: {send_credentials: '1'}
+        }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
   config.include Alchemy::TestSupport::ControllerRequests, :type => :controller
   config.include Alchemy::Engine.routes.url_helpers
   config.include FactoryGirl::Syntax::Methods
-  [:controller, :feature].each do |type|
+  [:controller, :feature, :request].each do |type|
     config.include Alchemy::TestSupport::IntegrationHelpers, type: type
   end
   config.before(:suite) do


### PR DESCRIPTION
If delivery errors happened, we got `DoubleRender` errors, because the delivery happened in an `after_filter`.

Now we send the mail inside the action. We now got the error message properly displayed.