### PR TITLE
Use newly renamed Alchemy::Admin::Locale

### DIFF
--- a/app/controllers/alchemy/passwords_controller.rb
+++ b/app/controllers/alchemy/passwords_controller.rb
@@ -1,6 +1,6 @@
 module Alchemy
   class PasswordsController < ::Devise::PasswordsController
-    include Alchemy::Locale
+    include Alchemy::Admin::Locale
 
     before_action { enforce_ssl if ssl_required? && !request.ssl? }
 

--- a/app/controllers/alchemy/user_sessions_controller.rb
+++ b/app/controllers/alchemy/user_sessions_controller.rb
@@ -1,6 +1,6 @@
 module Alchemy
   class UserSessionsController < ::Devise::SessionsController
-    include Alchemy::Locale
+    include Alchemy::Admin::Locale
 
     before_action except: 'destroy' do
       enforce_ssl if ssl_required? && !request.ssl?


### PR DESCRIPTION
Latest Alchemy 3.3-stable renamed the Alchemy::Locale into
Alchemy::Admin::Locale