### PR TITLE
Use authentication field as configured in devise

### DIFF
--- a/app/views/alchemy/user_sessions/new.html.erb
+++ b/app/views/alchemy/user_sessions/new.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="login_signup_box">
     <%= alchemy_form_for :user, url: {action: 'create'}, id: 'login' do |f| %>
-      <%= f.input :login, autofocus: true %>
+      <%= f.input Devise.authentication_keys.first, autofocus: true %>
       <%= f.input :password %>
       <p class="foot_note">
         <%= link_to Alchemy.t('Forgot your password?'), new_password_path %>

--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -2,5 +2,6 @@ de:
   simple_form:
     labels:
       user:
+        email: E-Mail
         login: Benutzername
         password: Passwort

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -2,5 +2,6 @@ es:
   simple_form:
     labels:
       user:
+        email: "Correo"
         login: Usuario
         password: Contraseña

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -2,5 +2,6 @@ fr:
   simple_form:
     labels:
       user:
+        email: "E-Mail"
         login: Nom d'utilisateur
         password: Mot de passe

--- a/spec/features/login_feature_spec.rb
+++ b/spec/features/login_feature_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "Login: " do
+  context "If users present" do
+    let!(:default_key) { Devise.authentication_keys }
+
+    before do
+      allow(Alchemy::User).to receive_messages(count: 1)
+    end
+
+    context "with Alchemy configuration" do
+      it "displays an login authentication field" do
+        visit '/admin/login'
+        expect(page).to have_field('user_login')
+      end
+    end
+
+    context "with default Devise configuration" do
+      before do
+        Devise.authentication_keys = [:email]
+      end
+
+      it "displays an email authentication field" do
+        visit '/admin/login'
+        expect(page).to have_field('user_email')
+      end
+
+      after do
+        Devise.authentication_keys = default_key
+      end
+    end
+  end
+end


### PR DESCRIPTION
One can configure in Devise the authentication_key used to authenticate
the user with. Default is :email, we use :login (for legacy reasons)

In order to respect this we need to display the field in the login form as
configured in the devise settings.