### PR TITLE
Remove subnavigation from module definition

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -10,12 +10,7 @@ Alchemy::Modules.register_module({
     name: 'modules.users',
     controller: 'alchemy/admin/users',
     action: 'index',
-    icon: 'users',
-    sub_navigation: [{
-      name: 'modules.users',
-      controller: 'alchemy/admin/users',
-      action: 'index'
-    }]
+    icon: 'users'
   }
 })
 


### PR DESCRIPTION
With the new menu of Alchemy 3.5 we don't need this anymore.