### PR TITLE
Require password reset for users signing in the first time

### DIFF
--- a/app/controllers/alchemy/passwords_controller.rb
+++ b/app/controllers/alchemy/passwords_controller.rb
@@ -3,6 +3,7 @@ module Alchemy
     include Alchemy::Admin::Locale
 
     before_action { enforce_ssl if ssl_required? && !request.ssl? }
+    skip_before_action :require_no_authentication, only: :edit
 
     helper 'Alchemy::Admin::Base'
 

--- a/app/controllers/alchemy/user_sessions_controller.rb
+++ b/app/controllers/alchemy/user_sessions_controller.rb
@@ -20,6 +20,9 @@ module Alchemy
       authenticate_user!
 
       if user_signed_in?
+        if reset_password_requested?
+          request_password_reset && return
+        end
         store_screen_size
         if session[:redirect_path].blank?
           redirect_path = admin_dashboard_path
@@ -60,6 +63,20 @@ module Alchemy
       else
         request.referer
       end
+    end
+
+    def request_password_reset
+      token = current_alchemy_user.send(:set_reset_password_token)
+      redirect_to edit_password_path(reset_password_token: token),
+        notice: Alchemy.t(:reset_password_after_first_login)
+    end
+
+    def reset_password_requested?
+      first_login? && current_alchemy_user.password_changed_at.nil?
+    end
+
+    def first_login?
+      current_alchemy_user.sign_in_count == 1
     end
   end
 end

--- a/app/models/alchemy/user.rb
+++ b/app/models/alchemy/user.rb
@@ -40,6 +40,8 @@ module Alchemy
     validates_uniqueness_of :login
     validates_presence_of :alchemy_roles
 
+    after_update :store_password_changed_time, if: :encrypted_password_changed?
+
     # Unlock all locked pages before destroy.
     before_destroy :unlock_pages!
 
@@ -182,6 +184,10 @@ module Alchemy
 
     def logged_in_timeout
       self.class.logged_in_timeout
+    end
+
+    def store_password_changed_time
+      update_column(:password_changed_at, Time.current)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Alchemy::Engine.routes.draw do
 
       get '/passwords' => 'passwords#new',
         :as => :new_password
-      get '/passwords/:id/edit/:reset_password_token' => 'passwords#edit',
+      get '/passwords/edit/:reset_password_token' => 'passwords#edit',
         :as => :edit_password
       post '/passwords' => 'passwords#create',
         :as => :reset_password

--- a/db/migrate/20161020101037_add_password_changed_at_to_alchemy_users.rb
+++ b/db/migrate/20161020101037_add_password_changed_at_to_alchemy_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordChangedAtToAlchemyUsers < ActiveRecord::Migration
+  def change
+    add_column :alchemy_users, :password_changed_at, :timestamp
+  end
+end

--- a/lib/alchemy/devise/test_support/factories.rb
+++ b/lib/alchemy/devise/test_support/factories.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     lastname 'Doe'
     password 's3cr3t'
     password_confirmation 's3cr3t'
+    password_changed_at { Time.current }
 
     factory :alchemy_admin_user do
       alchemy_roles 'admin'

--- a/spec/dummy/db/migrate/20161020101037_add_password_changed_at_to_alchemy_users.rb
+++ b/spec/dummy/db/migrate/20161020101037_add_password_changed_at_to_alchemy_users.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20161020101037_add_password_changed_at_to_alchemy_users.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160627081901) do
+ActiveRecord::Schema.define(version: 20161020101037) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -299,6 +299,7 @@ ActiveRecord::Schema.define(version: 20160627081901) do
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.string   "alchemy_roles",                      default: "member"
+    t.datetime "password_changed_at"
   end
 
   add_index "alchemy_users", ["alchemy_roles"], name: "index_alchemy_users_on_alchemy_roles"

--- a/spec/features/login_feature_spec.rb
+++ b/spec/features/login_feature_spec.rb
@@ -3,10 +3,7 @@ require 'spec_helper'
 describe "Login: " do
   context "If users present" do
     let!(:default_key) { Devise.authentication_keys }
-
-    before do
-      allow(Alchemy::User).to receive_messages(count: 1)
-    end
+    let!(:user) { create(:alchemy_admin_user) }
 
     context "with Alchemy configuration" do
       it "displays an login authentication field" do
@@ -27,6 +24,29 @@ describe "Login: " do
 
       after do
         Devise.authentication_keys = default_key
+      end
+    end
+
+    context "when the user signs in for the first time" do
+      before do
+        user.update_column(:sign_in_count, 0)
+      end
+
+      context "when the password has never changed before" do
+        before do
+          user.update_column(:password_changed_at, nil)
+        end
+
+        it 'requests a password reset', :aggregate_failures do
+          visit '/admin/login'
+
+          fill_in 'user_login', with: user.login
+          fill_in 'user_password', with: user.password
+          click_button 'login'
+
+          expect(page).to have_content(Alchemy.t(:reset_password_after_first_login))
+          expect(page).to have_field('user_password_confirmation')
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -302,5 +302,15 @@ module Alchemy
         expect(user.last_request_at).not_to eq(last_request_at)
       end
     end
+
+    describe "when password has changed" do
+      let(:user) { create(:alchemy_admin_user) }
+
+      it 'stores changed password time' do
+        expect {
+          user.reset_password('n3wP4$$w0rd', 'n3wP4$$w0rd')
+        }.to change { user.password_changed_at }
+      end
+    end
   end
 end

--- a/spec/routing/password_routing_spec.rb
+++ b/spec/routing/password_routing_spec.rb
@@ -23,11 +23,10 @@ describe "Password Routing" do
 
   it "routes to edit password" do
     expect({
-      get: "/admin/passwords/123/edit/12345"
+      get: "/admin/passwords/edit/12345"
     }).to route_to(
       controller: "alchemy/passwords",
       action: "edit",
-      id: "123",
       reset_password_token: "12345"
     )
   end


### PR DESCRIPTION
By storing the `password_changed_at` time and by checking the `sign_in_count` we require users that sign in the first time to reset their password.

This only effects users that get created by other users either through the console, a seeder or by using the admin users form. Users signing up through the sign up form are not affected, because the sign up counts as first sign in.

If you want to opt out of this you simply can set `password_changed_at` to a date in the past in your seeder.