### PR TITLE
Allow to configure devise modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ $ bundle update alchemy-devise
 $ bin/rails g alchemy:devise:install
 ```
 
+## Devise modules
+
+Default Devise modules included in `Alchemy::User` model
+
+- `:database_authenticatable`
+- `:trackable`
+- `:validatable`
+- `:timeoutable`
+- `:recoverable`
+
+If you want to add additional modules into the Alchemy user class append them to `Alchemy.devise_modules` in an initializer in your app.
+
+### Register additional modules example
+
+```ruby
+# config/initializers/alchemy.rb
+Alchemy.devise_modules << :registerable
+```
+
+### Using old encryption
+
+If your app uses an old encryption that needs the +devise-encryptable+ gem you also need to load the devise module.
+
+```ruby
+# config/initializers/alchemy.rb
+Alchemy.devise_modules << :encryptable
+```
+
 ## Testing
 
 If you want to contribute (and you should ^_^), you need to run the tests locally on your machine.

--- a/app/models/alchemy/user.rb
+++ b/app/models/alchemy/user.rb
@@ -16,19 +16,8 @@ module Alchemy
       :send_credentials,
       :tag_list
     ]
-    DEVISE_MODULES = [
-      :database_authenticatable,
-      :trackable,
-      :validatable,
-      :timeoutable,
-      :recoverable
-    ]
-    # If the app uses an old encryption it uses the devise-encryptable gem
-    # therefore we have to load the devise module
-    if (::Devise::Models::Encryptable rescue false)
-      DEVISE_MODULES.push(:encryptable)
-    end
-    devise *DEVISE_MODULES
+
+    devise *Alchemy.devise_modules
 
     acts_as_taggable
     acts_as_tagger

--- a/lib/alchemy/devise.rb
+++ b/lib/alchemy/devise.rb
@@ -1,6 +1,41 @@
 require "alchemy/devise/engine"
 
 module Alchemy
+  # Devise modules included in +Alchemy::User+ model
+  #
+  # === Default modules
+  #
+  #     [
+  #.      :database_authenticatable,
+  #       :trackable,
+  #       :validatable,
+  #       :timeoutable,
+  #       :recoverable
+  #.    ]
+  #
+  # If you want to add additional modules into the Alchemy user class append
+  # them to this collection in an initializer in your app.
+  #
+  # === Example
+  #
+  #     # config/initializers/alchemy.rb
+  #     Alchemy.devise_modules << :registerable
+  #
+  # If your app uses an old encryption that needs the +devise-encryptable+ gem
+  # you also need to load the devise module.
+  #
+  #     Alchemy.devise_modules << :encryptable
+  #
+  def self.devise_modules
+    @devise_modules ||= [
+      :database_authenticatable,
+      :trackable,
+      :validatable,
+      :timeoutable,
+      :recoverable
+    ]
+  end
+
   module Devise
   end
 end


### PR DESCRIPTION
In order to be able to configure additional devise modules for
the `Alchemy::User` model we introduce `Alchemy.devise_modules`.