### PR TITLE
Build for Rails 5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'rails', '~> 5.1.6'
 gem 'alchemy_cms', github: 'AlchemyCMS/alchemy_cms', branch: 'master'
 gem 'sassc-rails'
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -10,11 +10,16 @@ require "sprockets/railtie"
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
 
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 require "alchemy/devise"
 
 module Dummy
   class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 5.1
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -2,24 +2,24 @@
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.
 #
-# Once upgraded flip defaults one by one to migrate to the new default.
-#
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-Rails.application.config.raise_on_unfiltered_parameters = true
-
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+Rails.application.config.action_controller.forgery_protection_origin_check = true
+Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
+ActiveSupport.to_time_preserves_timezone = true
 
 # Require `belongs_to` associations by default. Previous versions had false.
-Rails.application.config.active_record.belongs_to_required_by_default = false
+Rails.application.config.active_record.belongs_to_required_by_default = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true
+# Configure SSL options to enable HSTS with subdomains. Previous versions had false.
+Rails.application.config.ssl_options = { hsts: { subdomains: true } }
+
+# The Event model of the dummy app has a time column. Time columns will become time zone aware in Rails 5.1
+ActiveRecord::Base.time_zone_aware_types = [:datetime, :time]

--- a/spec/dummy/config/initializers/new_framework_defaults_5_1.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults_5_1.rb
@@ -1,0 +1,14 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.1 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Make `form_with` generate non-remote forms.
+Rails.application.config.action_view.form_with_generates_remote_forms = false
+
+# Unknown asset fallback will return the path passed in when the given
+# asset is not present in the asset pipeline.
+# Rails.application.config.assets.unknown_asset_fallback = false


### PR DESCRIPTION
Not all of our dependencies are Rails 5.2 compatible yet. That's why we
need to stick with Rails 5.1 for now.