### PR TITLE
Only allow Alchemy > 4.1

### DIFF
--- a/alchemy-devise.gemspec
+++ b/alchemy-devise.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "alchemy_cms", [">= 4.0.0.beta", "< 4.99"]
+  s.add_dependency "alchemy_cms", [">= 4.1.0.beta", "< 4.99"]
   s.add_dependency "devise",      [">= 4.0", "< 4.99"]
 
   s.add_development_dependency "capybara"


### PR DESCRIPTION
Alchemy 4.1 introduced a new color theme and icons that we adopted.
So being compatible with Alchemy 4.0 does not make any sense.

Use the 4.0 versions in order to use this gem with Alchemy 4.0