### PR TITLE
Fix translation key on user admin page

### DIFF
--- a/app/views/alchemy/admin/users/_user.html.erb
+++ b/app/views/alchemy/admin/users/_user.html.erb
@@ -17,7 +17,7 @@
   <td><%= user.lastname %></td>
   <td class="email"><%= user.email %></td>
   <td><%= Alchemy.t(user.language, scope: 'translations', default: Alchemy.t(:unknown)) %></td>
-  <td><%= user.last_sign_in_at.present? ? l(user.last_sign_in_at, format: :default) : Alchemy.t(:unknown) %></td>
+  <td><%= user.last_sign_in_at.present? ? l(user.last_sign_in_at, format: 'alchemy.default'.to_sym) : Alchemy.t(:unknown) %></td>
   <td class="role"><%= user.human_roles_string %></td>
   <td class="tools">
   <% if can?(:destroy, user) %>


### PR DESCRIPTION
The translation keys are namespaced in the `alchemy_i18n` repository.
This commit fixes the user admin page so the key is in line with those keys.