### PR TITLE
Remove test files from built Ruby gem

### DIFF
--- a/alchemy-devise.gemspec
+++ b/alchemy-devise.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.description = "Devise based user authentication for AlchemyCMS."
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
-  s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "alchemy_cms", [">= 4.1.0.beta", "< 4.99"]
   s.add_dependency "devise",      [">= 4.6.0", "< 4.99"]


### PR DESCRIPTION
We do not need those file in the Ruby gem build. Reduces filesize a lot.