### PR TITLE
Rename Alchemy::BaseController extension constant

### DIFF
--- a/app/controllers/alchemy/base_controller_extension.rb
+++ b/app/controllers/alchemy/base_controller_extension.rb
@@ -1,12 +1,18 @@
-Alchemy::BaseController.class_eval do
-  before_action :store_user_request_time
+module Alchemy
+  module BaseControllerExtension
+    def self.prepended(base)
+      base.before_action(:store_user_request_time)
+    end
 
-  private
+    private
 
-  # Stores the users request time.
-  def store_user_request_time
-    if alchemy_user_signed_in?
-      current_alchemy_user.store_request_time!
+    # Stores the users request time.
+    def store_user_request_time
+      if alchemy_user_signed_in?
+        current_alchemy_user.store_request_time!
+      end
     end
   end
 end
+
+Alchemy::BaseController.prepend Alchemy::BaseControllerExtension


### PR DESCRIPTION
In Rails 6 with Zeitwerk we need to make sure that a file contains
the constant we the same naming schema. Although the dummy app uses
the exact same Rails 6 defaults as a "normal" Rails app this was
never catched in specs but in real world apps.