### PR TITLE
Remove gender

### DIFF
--- a/app/controllers/alchemy/admin/users_controller.rb
+++ b/app/controllers/alchemy/admin/users_controller.rb
@@ -2,7 +2,7 @@ module Alchemy
   module Admin
     class UsersController < ResourcesController
 
-      before_action :set_roles_and_genders, except: [:index, :destroy]
+      before_action :set_roles, except: [:index, :destroy]
 
       load_and_authorize_resource class: Alchemy::User,
         only: [:edit, :update, :destroy]
@@ -67,13 +67,12 @@ module Alchemy
 
       private
 
-      def set_roles_and_genders
+      def set_roles
         if can_update_role?
           @user_roles = User::ROLES.map do |role|
             [User.human_rolename(role), role]
           end
         end
-        @user_genders = User.genders_for_select
       end
 
       def user_params

--- a/app/models/alchemy/user.rb
+++ b/app/models/alchemy/user.rb
@@ -8,7 +8,6 @@ module Alchemy
       :lastname,
       :login,
       :email,
-      :gender,
       :language,
       :password,
       :password_confirmation,
@@ -39,13 +38,6 @@ module Alchemy
     class << self
       def human_rolename(role)
         Alchemy.t("user_roles.#{role}")
-      end
-
-      def genders_for_select
-        [
-          [Alchemy.t('male'), 'male'],
-          [Alchemy.t('female'), 'female']
-        ]
       end
 
       def logged_in_timeout

--- a/app/views/alchemy/admin/users/_fields.html.erb
+++ b/app/views/alchemy/admin/users/_fields.html.erb
@@ -1,7 +1,3 @@
-<%= f.input :gender,
-  collection: @user_genders,
-  prompt: Alchemy.t('Please choose'),
-  input_html: {class: 'alchemy_selectbox'} %>
 <%= f.input :firstname %>
 <%= f.input :lastname %>
 <%= f.input :login, autofocus: true %>

--- a/db/migrate/20131015124700_create_alchemy_users.rb
+++ b/db/migrate/20131015124700_create_alchemy_users.rb
@@ -6,7 +6,6 @@ class CreateAlchemyUsers < ActiveRecord::Migration[4.2]
       t.string   "lastname"
       t.string   "login"
       t.string   "email"
-      t.string   "gender"
       t.string   "language"
       t.string   "encrypted_password",     limit: 128, default: "",       null: false
       t.string   "password_salt",          limit: 128, default: "",       null: false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -276,7 +276,6 @@ ActiveRecord::Schema.define(version: 2019_04_24_075603) do
     t.string "lastname"
     t.string "login"
     t.string "email"
-    t.string "gender"
     t.string "language"
     t.string "encrypted_password", limit: 128, default: "", null: false
     t.string "password_salt", limit: 128, default: "", null: false


### PR DESCRIPTION
Removed the gender column from existing migration to preserve gender data in existing databases. Removed gender and related methods from controller, model, and form.