### PR TITLE
Allow Alchemy 5.0

### DIFF
--- a/alchemy-devise.gemspec
+++ b/alchemy-devise.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "alchemy_cms", [">= 4.1.0.beta", "< 4.99"]
-  s.add_dependency "devise",      [">= 4.7.1", "< 4.99"]
+  s.add_dependency "alchemy_cms", [">= 4.1.0", "< 5.1"]
+  s.add_dependency "devise",      [">= 4.7.1", "< 5"]
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "factory_bot_rails"


### PR DESCRIPTION
Not yet released, but we already support it.