### PR TITLE
Remove require_ssl from User Sessions Controller for Alchemy 5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: trusty
+dist: bionic
 sudo: false
 cache:
   bundler: true

--- a/app/controllers/alchemy/admin/passwords_controller.rb
+++ b/app/controllers/alchemy/admin/passwords_controller.rb
@@ -7,9 +7,9 @@ module Alchemy
         before_action { enforce_ssl if ssl_required? && !request.ssl? }
       end
 
-      helper 'Alchemy::Admin::Base'
+      helper "Alchemy::Admin::Base"
 
-      layout 'alchemy/admin'
+      layout "alchemy/admin"
 
       private
 
@@ -18,7 +18,7 @@ module Alchemy
         alchemy.admin_login_path
       end
 
-      def admin_edit_password_url(resource, options={})
+      def admin_edit_password_url(_resource, options = {})
         alchemy.admin_edit_password_url(options)
       end
 
@@ -29,7 +29,6 @@ module Alchemy
           alchemy.root_path
         end
       end
-
     end
   end
 end

--- a/app/controllers/alchemy/admin/passwords_controller.rb
+++ b/app/controllers/alchemy/admin/passwords_controller.rb
@@ -3,7 +3,9 @@ module Alchemy
     class PasswordsController < ::Devise::PasswordsController
       include Alchemy::Admin::Locale
 
-      before_action { enforce_ssl if ssl_required? && !request.ssl? }
+      if Alchemy.gem_version <= Gem::Version.new("4.9")
+        before_action { enforce_ssl if ssl_required? && !request.ssl? }
+      end
 
       helper 'Alchemy::Admin::Base'
 

--- a/app/controllers/alchemy/admin/user_sessions_controller.rb
+++ b/app/controllers/alchemy/admin/user_sessions_controller.rb
@@ -1,4 +1,6 @@
-require_dependency 'alchemy/version'
+# frozen_string_literal: true
+
+require_dependency "alchemy/version"
 
 module Alchemy
   module Admin
@@ -8,15 +10,15 @@ module Alchemy
       protect_from_forgery prepend: true
 
       if Alchemy.gem_version <= Gem::Version.new("4.9")
-        before_action except: 'destroy' do
+        before_action except: "destroy" do
           enforce_ssl if ssl_required? && !request.ssl?
         end
       end
       before_action :check_user_count, :only => :new
 
-      helper 'Alchemy::Admin::Base'
+      helper "Alchemy::Admin::Base"
 
-      layout 'alchemy/admin'
+      layout "alchemy/admin"
 
       def create
         authenticate_user!
@@ -26,10 +28,10 @@ module Alchemy
             redirect_path = admin_dashboard_path
           else
             # We have to strip double slashes from beginning of path, because of strange rails/rack bug.
-            redirect_path = session[:redirect_path].gsub(/\A\/{2,}/, '/')
+            redirect_path = session[:redirect_path].gsub(/\A\/{2,}/, "/")
           end
           redirect_to redirect_path,
-            notice: t(:signed_in, scope: 'devise.sessions')
+            notice: t(:signed_in, scope: "devise.sessions")
         else
           super
         end

--- a/app/controllers/alchemy/admin/user_sessions_controller.rb
+++ b/app/controllers/alchemy/admin/user_sessions_controller.rb
@@ -1,3 +1,5 @@
+require_dependency 'alchemy/version'
+
 module Alchemy
   module Admin
     class UserSessionsController < ::Devise::SessionsController
@@ -5,10 +7,11 @@ module Alchemy
 
       protect_from_forgery prepend: true
 
-      before_action except: 'destroy' do
-        enforce_ssl if ssl_required? && !request.ssl?
+      if Alchemy.gem_version <= Gem::Version.new("4.9")
+        before_action except: 'destroy' do
+          enforce_ssl if ssl_required? && !request.ssl?
+        end
       end
-
       before_action :check_user_count, :only => :new
 
       helper 'Alchemy::Admin::Base'

--- a/spec/controllers/admin/user_sessions_controller_spec.rb
+++ b/spec/controllers/admin/user_sessions_controller_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 describe Alchemy::Admin::UserSessionsController do
   routes { Alchemy::Engine.routes }
@@ -7,23 +9,23 @@ describe Alchemy::Admin::UserSessionsController do
     @request.env["devise.mapping"] = Devise.mappings[:user]
   end
 
-  context 'without users present' do
-    describe '#new' do
+  context "without users present" do
+    describe "#new" do
       it "redirects to signup form" do
         get :new
         is_expected.to redirect_to(admin_signup_path)
       end
 
       if Alchemy.gem_version <= Gem::Version.new("4.9")
-        context 'with ssl enforced' do
+        context "with ssl enforced" do
           before do
             allow(controller).to receive(:ssl_required?).and_return(true)
           end
 
-          it 'redirects to https' do
+          it "redirects to https" do
             get :new
             is_expected.to redirect_to(
-              admin_login_url(protocol: 'https', host: "test.host")
+              admin_login_url(protocol: "https", host: "test.host"),
             )
           end
         end
@@ -31,34 +33,34 @@ describe Alchemy::Admin::UserSessionsController do
     end
   end
 
-  context 'with users present' do
+  context "with users present" do
     let(:user) { create(:alchemy_admin_user) }
 
-    describe '#create' do
-      context 'with valid user' do
-        let(:screen_size) {'1200x800'}
-        let(:user_params) { {login: user.login, password: 's3cr3t'} }
+    describe "#create" do
+      context "with valid user" do
+        let(:screen_size) { "1200x800" }
+        let(:user_params) { { login: user.login, password: "s3cr3t" } }
 
         before { user }
 
-        context 'without redirect path in session' do
+        context "without redirect path in session" do
           it "redirects to dashboard" do
-            post :create, params: {user: user_params}
+            post :create, params: { user: user_params }
             expect(response).to redirect_to(admin_dashboard_path)
           end
         end
 
-        context 'with redirect path in session' do
+        context "with redirect path in session" do
           it "redirects to these params" do
             session[:redirect_path] = admin_users_path
-            post :create, params: {user: user_params}
+            post :create, params: { user: user_params }
             expect(response).to redirect_to(admin_users_path)
           end
         end
 
-        context 'without valid params' do
+        context "without valid params" do
           it "renders login form" do
-            post :create, params: {user: {login: ''}}
+            post :create, params: { user: { login: "" } }
             is_expected.to render_template(:new)
           end
         end
@@ -68,9 +70,8 @@ describe Alchemy::Admin::UserSessionsController do
     describe "#destroy" do
       before do
         allow(controller).to receive(:store_user_request_time)
-        allow(controller)
-          .to receive(:all_signed_out?)
-          .and_return(false)
+        allow(controller).to receive(:all_signed_out?)
+                               .and_return(false)
         authorize_user(user)
       end
 
@@ -79,10 +80,10 @@ describe Alchemy::Admin::UserSessionsController do
         delete :destroy
       end
 
-      context 'comming from admin area' do
+      context "comming from admin area" do
         before do
           allow_any_instance_of(ActionController::TestRequest).to receive(:referer) do
-            '/admin_users'
+            "/admin_users"
           end
         end
 
@@ -92,7 +93,7 @@ describe Alchemy::Admin::UserSessionsController do
         end
       end
 
-      context 'no referer present' do
+      context "no referer present" do
         before do
           allow_any_instance_of(ActionController::TestRequest).to receive(:referer) do
             nil
@@ -105,16 +106,16 @@ describe Alchemy::Admin::UserSessionsController do
         end
       end
 
-      context 'referer not from admin area' do
+      context "referer not from admin area" do
         before do
           allow_any_instance_of(ActionController::TestRequest).to receive(:referer) do
-            '/imprint'
+            "/imprint"
           end
         end
 
         it "redirects to root" do
           delete :destroy
-          is_expected.to redirect_to('/imprint')
+          is_expected.to redirect_to("/imprint")
         end
       end
     end

--- a/spec/controllers/admin/user_sessions_controller_spec.rb
+++ b/spec/controllers/admin/user_sessions_controller_spec.rb
@@ -14,16 +14,18 @@ describe Alchemy::Admin::UserSessionsController do
         is_expected.to redirect_to(admin_signup_path)
       end
 
-      context 'with ssl enforced' do
-        before do
-          allow(controller).to receive(:ssl_required?).and_return(true)
-        end
+      if Alchemy.gem_version <= Gem::Version.new("4.9")
+        context 'with ssl enforced' do
+          before do
+            allow(controller).to receive(:ssl_required?).and_return(true)
+          end
 
-        it 'redirects to https' do
-          get :new
-          is_expected.to redirect_to(
-            admin_login_url(protocol: 'https', host: "test.host")
-          )
+          it 'redirects to https' do
+            get :new
+            is_expected.to redirect_to(
+              admin_login_url(protocol: 'https', host: "test.host")
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
This feature has been removed from Alchemy, under the assumption that it
is better handled at other levels than the content management system.

Inside  `alchemy-devise`, we want to try to stay compatible to the last three Alchemy versions. This fixes the build on Alchemy `master`.