### PR TITLE
Use absolute paths in Alchemy module definition

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -1,23 +1,23 @@
-require 'alchemy/devise/ability'
+require "alchemy/devise/ability"
 
 Alchemy.register_ability(Alchemy::Devise::Ability)
 
 Alchemy::Modules.register_module({
-  name: 'users',
-  engine_name: 'alchemy',
+  name: "users",
+  engine_name: "alchemy",
   position: 4.1,
   navigation: {
-    name: 'modules.users',
-    controller: '/alchemy/admin/users',
-    action: 'index',
-    icon: 'users'
-  }
+    name: "modules.users",
+    controller: "/alchemy/admin/users",
+    action: "index",
+    icon: "users",
+  },
 })
 
-Alchemy.user_class_name = 'Alchemy::User'
-Alchemy.signup_path     = '/admin/signup'
-Alchemy.login_path      = '/admin/login'
-Alchemy.logout_path     = '/admin/logout'
+Alchemy.user_class_name = "Alchemy::User"
+Alchemy.signup_path = "/admin/signup"
+Alchemy.login_path = "/admin/login"
+Alchemy.logout_path = "/admin/logout"
 
 if Alchemy.respond_to?(:logout_method)
   Rails.application.config.after_initialize do

--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "alchemy/devise/ability"
 
 Alchemy.register_ability(Alchemy::Devise::Ability)

--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -8,7 +8,7 @@ Alchemy::Modules.register_module({
   position: 4.1,
   navigation: {
     name: 'modules.users',
-    controller: 'alchemy/admin/users',
+    controller: '/alchemy/admin/users',
     action: 'index',
     icon: 'users'
   }


### PR DESCRIPTION
If we have a nested controller the Alchemy main navigation is not able to resolve the routes if we not use absolute paths.