### PR TITLE
Drop Alchemy.gem_version

### DIFF
--- a/app/controllers/alchemy/admin/passwords_controller.rb
+++ b/app/controllers/alchemy/admin/passwords_controller.rb
@@ -3,7 +3,7 @@ module Alchemy
     class PasswordsController < ::Devise::PasswordsController
       include Alchemy::Admin::Locale
 
-      if Gem.loaded_specs['alchemy_cms'].version <= Gem::Version.new("4.9")
+      if Gem.loaded_specs["alchemy_cms"].version <= Gem::Version.new("4.9")
         before_action { enforce_ssl if ssl_required? && !request.ssl? }
       end
 

--- a/app/controllers/alchemy/admin/passwords_controller.rb
+++ b/app/controllers/alchemy/admin/passwords_controller.rb
@@ -3,7 +3,7 @@ module Alchemy
     class PasswordsController < ::Devise::PasswordsController
       include Alchemy::Admin::Locale
 
-      if Alchemy.gem_version <= Gem::Version.new("4.9")
+      if Gem.loaded_specs['alchemy_cms'].version <= Gem::Version.new("4.9")
         before_action { enforce_ssl if ssl_required? && !request.ssl? }
       end
 


### PR DESCRIPTION
I was not able to use that gem with Alchemy `master` thanks to the fact that `Alchemy.gem_version` is undefined. This change fixes it for me 