### PR TITLE
Require alchemy/version in controllers using ssl_required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: ALCHEMY_BRANCH=main
+before_script: nvm use 12
 script: bundle exec rake

--- a/app/controllers/alchemy/admin/passwords_controller.rb
+++ b/app/controllers/alchemy/admin/passwords_controller.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "alchemy/version"
+
 module Alchemy
   module Admin
     class PasswordsController < ::Devise::PasswordsController

--- a/app/controllers/alchemy/admin/user_sessions_controller.rb
+++ b/app/controllers/alchemy/admin/user_sessions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_dependency "alchemy/version"
+require "alchemy/version"
 
 module Alchemy
   module Admin


### PR DESCRIPTION
We need to `require "alchemy/version"` in these controllers to
be able to read the `Alchemy.gem_version`. This file is not
required anywhere and the method will not be defined otherwise.

Closes #111