### PR TITLE
Use Alchemy::User as class in ability

### DIFF
--- a/lib/alchemy/devise/ability.rb
+++ b/lib/alchemy/devise/ability.rb
@@ -10,16 +10,16 @@ module Alchemy
         can :create, Alchemy::User if Alchemy::User.count == 0
 
         if member? || author? || editor?
-          can [:show, :update], Alchemy.user_class, id: user.id
+          can [:show, :update], Alchemy::User, id: user.id
         end
 
         if editor? || admin?
           can :index, :alchemy_admin_users
-          can :read, Alchemy.user_class
+          can :read, Alchemy::User
         end
 
         if admin?
-          can :manage, Alchemy.user_class
+          can :manage, Alchemy::User
         end
       end
 


### PR DESCRIPTION
Using `Alchemy.user_class` can lead to object id based issues. Since
we define `Alchemy::User` as the `Alchemy.user_class` we do not need
to use the proxy here and can use the actual class instead.

This fixes issues where admin users cannot access the Users admin
views, although it should be possible.