### PR TITLE
Allow setting a layout for user_sessions and passwords controller

### DIFF
--- a/app/controllers/alchemy/admin/passwords_controller.rb
+++ b/app/controllers/alchemy/admin/passwords_controller.rb
@@ -13,7 +13,7 @@ module Alchemy
 
       helper "Alchemy::Admin::Base"
 
-      layout "alchemy/admin"
+      layout Alchemy::Devise.layout
 
       private
 

--- a/app/controllers/alchemy/admin/user_sessions_controller.rb
+++ b/app/controllers/alchemy/admin/user_sessions_controller.rb
@@ -18,7 +18,7 @@ module Alchemy
 
       helper "Alchemy::Admin::Base"
 
-      layout "alchemy/admin"
+      layout Alchemy::Devise.layout
 
       def create
         authenticate_user!

--- a/lib/alchemy/devise.rb
+++ b/lib/alchemy/devise.rb
@@ -37,5 +37,12 @@ module Alchemy
   end
 
   module Devise
+    def self.layout=(value)
+      @layout = value
+    end
+
+    def self.layout
+      @layout || "alchemy/admin"
+    end
   end
 end


### PR DESCRIPTION
A layout can be set using an initializer in the host app.

```
Alchemy::Devise.layout = "login"
```

The fallback value ensures backwards compatibility.