### PR TITLE
Wrap initializer in config.to_prepare block

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -1,28 +1,25 @@
 # frozen_string_literal: true
 
-require "alchemy/devise/ability"
+Rails.application.config.to_prepare do
+  require "alchemy/devise/ability"
 
-Alchemy.register_ability(Alchemy::Devise::Ability)
+  Alchemy.register_ability(Alchemy::Devise::Ability)
 
-Alchemy::Modules.register_module({
-  name: "users",
-  engine_name: "alchemy",
-  position: 4.1,
-  navigation: {
-    name: "modules.users",
-    controller: "/alchemy/admin/users",
-    action: "index",
-    icon: "users",
-  },
-})
+  Alchemy::Modules.register_module({
+    name: "users",
+    engine_name: "alchemy",
+    position: 4.1,
+    navigation: {
+      name: "modules.users",
+      controller: "/alchemy/admin/users",
+      action: "index",
+      icon: "users",
+    },
+  })
 
-Alchemy.user_class_name = "Alchemy::User"
-Alchemy.signup_path = "/admin/signup"
-Alchemy.login_path = "/admin/login"
-Alchemy.logout_path = "/admin/logout"
-
-if Alchemy.respond_to?(:logout_method)
-  Rails.application.config.after_initialize do
-    Alchemy.logout_method = Devise.sign_out_via
-  end
+  Alchemy.user_class_name = "Alchemy::User"
+  Alchemy.signup_path = "/admin/signup"
+  Alchemy.login_path = "/admin/login"
+  Alchemy.logout_path = "/admin/logout"
+  Alchemy.logout_method = Devise.sign_out_via
 end


### PR DESCRIPTION
Without this, Rails will autoload all of Alchemy on app initialization,
a behaviour that is deprecated in Rails 6.