### PR TITLE
Use minor versions for Ruby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           - 5.1-stable
           - main
         ruby:
-          - '2.5.8'
-          - '2.6.6'
-          - '2.7.2'
+          - '2.5'
+          - '2.6'
+          - '2.7'
         database:
           - mysql
           - postgresql


### PR DESCRIPTION
Sticking to revisions seems to break when those versions go out of
fashion.