### PR TITLE
Use standard.rb to lint code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,16 @@ jobs:
         with:
           name: Screenshots
           path: spec/dummy/tmp/screenshots
+
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+          bundler-cache: true
+      - name: Lint Ruby files
+        run: bundle exec standardrb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+require: standard
+
+AllCops:
+  TargetRubyVersion: 3.0
+
+inherit_gem:
+  standard: config/base.yml

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,3 @@
+parallel: true
+ignore:
+  - "spec/dummy/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,5 @@ group :test do
 end
 
 gem "github_fast_changelog", require: false
+
+gem "standardrb", "~> 1.0", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => ["alchemy:spec:prepare", :spec]
+task default: ["alchemy:spec:prepare", :spec]
 
 Bundler::GemHelper.install_tasks
 

--- a/app/controllers/alchemy/admin/user_sessions_controller.rb
+++ b/app/controllers/alchemy/admin/user_sessions_controller.rb
@@ -9,7 +9,7 @@ module Alchemy
 
       protect_from_forgery prepend: true
 
-      before_action :check_user_count, :only => :new
+      before_action :check_user_count, only: :new
 
       helper "Alchemy::Admin::Base"
 
@@ -19,11 +19,11 @@ module Alchemy
         authenticate_user!
 
         if user_signed_in?
-          if session[:redirect_path].blank?
-            redirect_path = admin_dashboard_path
+          redirect_path = if session[:redirect_path].blank?
+            admin_dashboard_path
           else
             # We have to strip double slashes from beginning of path, because of strange rails/rack bug.
-            redirect_path = session[:redirect_path].gsub(/\A\/{2,}/, "/")
+            session[:redirect_path].gsub(/\A\/{2,}/, "/")
           end
           redirect_to redirect_path,
             notice: t(:signed_in, scope: "devise.sessions")

--- a/app/controllers/alchemy/admin/users_controller.rb
+++ b/app/controllers/alchemy/admin/users_controller.rb
@@ -1,7 +1,6 @@
 module Alchemy
   module Admin
     class UsersController < ResourcesController
-
       before_action :set_roles, except: [:index, :destroy]
 
       load_and_authorize_resource class: Alchemy::User,
@@ -14,7 +13,7 @@ module Alchemy
 
       def index
         @query = User.ransack(params[:q])
-        @query.sorts = 'login asc' if @query.sorts.empty?
+        @query.sorts = "login asc" if @query.sorts.empty?
         @users = @query.result
           .page(params[:page] || 1)
           .per(items_per_page)
@@ -53,7 +52,7 @@ module Alchemy
         deliver_welcome_mail
         render_errors_or_redirect @user,
           admin_users_path,
-          Alchemy.t("User updated", :name => @user.name)
+          Alchemy.t("User updated", name: @user.name)
       end
 
       def destroy
@@ -92,9 +91,9 @@ module Alchemy
       end
 
       def signup_admin_or_redirect
-        @user.alchemy_roles = %w(admin)
+        @user.alchemy_roles = %w[admin]
         if @user.save
-          flash[:notice] = Alchemy.t('Successfully signup admin user')
+          flash[:notice] = Alchemy.t("Successfully signup admin user")
           sign_in :user, @user
           deliver_welcome_mail
           redirect_to admin_pages_path
@@ -116,7 +115,7 @@ module Alchemy
       end
 
       def deliver_welcome_mail
-        if @user.valid? && @user.send_credentials == '1'
+        if @user.valid? && @user.send_credentials == "1"
           @user.deliver_welcome_mail
         end
       end

--- a/app/mailers/alchemy/notifications.rb
+++ b/app/mailers/alchemy/notifications.rb
@@ -1,7 +1,6 @@
 module Alchemy
   class Notifications < ActionMailer::Base
-
-    default(from: Config.get(:mailer)['mail_from'])
+    default(from: Config.get(:mailer)["mail_from"])
 
     def member_created(user)
       @user = user
@@ -21,7 +20,7 @@ module Alchemy
       )
     end
 
-    def reset_password_instructions(user, token, opts={})
+    def reset_password_instructions(user, token, opts = {})
       @user = user
       @token = token
       mail(

--- a/app/models/alchemy/user.rb
+++ b/app/models/alchemy/user.rb
@@ -14,10 +14,10 @@ module Alchemy
       :password,
       :password_confirmation,
       :send_credentials,
-      :tag_list,
+      :tag_list
     ]
 
-    devise *Alchemy.devise_modules
+    devise(*Alchemy.devise_modules)
 
     include Alchemy::Taggable
 
@@ -86,7 +86,7 @@ module Alchemy
     end
 
     def add_role(role)
-      self.alchemy_roles = self.alchemy_roles.push(role.to_s).uniq
+      self.alchemy_roles = alchemy_roles.push(role.to_s).uniq
     end
 
     # Returns true if the user ahs admin role
@@ -127,7 +127,7 @@ module Alchemy
       if lastname.blank? && firstname.blank?
         login
       else
-        options = { flipped: false }.merge(options)
+        options = {flipped: false}.merge(options)
         fullname = options[:flipped] ? "#{lastname}, #{firstname}" : "#{firstname} #{lastname}"
         fullname.squeeze(" ").strip
       end

--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -13,8 +13,8 @@ Rails.application.config.to_prepare do
       name: "modules.users",
       controller: "/alchemy/admin/users",
       action: "index",
-      icon: "users",
-    },
+      icon: "users"
+    }
   })
 
   Alchemy.signup_path = "/admin/signup"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,35 +3,34 @@ Alchemy::Engine.routes.draw do
     path: Alchemy.admin_path,
     constraints: Alchemy.admin_constraints
   } do
-
     devise_for :user,
-      class_name: 'Alchemy::User',
+      class_name: "Alchemy::User",
       singular: :user,
       skip: :all,
       controllers: {
-        sessions: 'alchemy/admin/user_sessions',
-        passwords: 'alchemy/admin/passwords'
+        sessions: "alchemy/admin/user_sessions",
+        passwords: "alchemy/admin/passwords"
       },
       router_name: :alchemy
 
     devise_scope :user do
-      get '/dashboard' => 'dashboard#index',
+      get "/dashboard" => "dashboard#index",
         :as => :user_root
-      get '/signup' => 'users#signup',
+      get "/signup" => "users#signup",
         :as => :signup
-      get '/login' => 'user_sessions#new',
+      get "/login" => "user_sessions#new",
         :as => :login
-      post '/login' => 'user_sessions#create'
-      match '/logout' => 'user_sessions#destroy',
-        :as => :logout, via: Devise.sign_out_via
+      post "/login" => "user_sessions#create"
+      match "/logout" => "user_sessions#destroy",
+        :as => :logout, :via => Devise.sign_out_via
 
-      get '/passwords' => 'passwords#new',
+      get "/passwords" => "passwords#new",
         :as => :new_password
-      get '/passwords/:id/edit/:reset_password_token' => 'passwords#edit',
+      get "/passwords/:id/edit/:reset_password_token" => "passwords#edit",
         :as => :edit_password
-      post '/passwords' => 'passwords#create',
+      post "/passwords" => "passwords#create",
         :as => :reset_password
-      patch '/passwords' => 'passwords#update',
+      patch "/passwords" => "passwords#update",
         :as => :update_password
     end
 

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,1 +1,1 @@
-Spring.application_root = 'spec/dummy'
+Spring.application_root = "spec/dummy"

--- a/db/migrate/20131015124700_create_alchemy_users.rb
+++ b/db/migrate/20131015124700_create_alchemy_users.rb
@@ -2,26 +2,26 @@ class CreateAlchemyUsers < ActiveRecord::Migration[4.2]
   def up
     return if table_exists?(:alchemy_users)
     create_table "alchemy_users" do |t|
-      t.string   "firstname"
-      t.string   "lastname"
-      t.string   "login"
-      t.string   "email"
-      t.string   "language"
-      t.string   "encrypted_password",     limit: 128, default: "",       null: false
-      t.string   "password_salt",          limit: 128, default: "",       null: false
-      t.integer  "sign_in_count",                      default: 0,        null: false
-      t.integer  "failed_attempts",                    default: 0,        null: false
+      t.string "firstname"
+      t.string "lastname"
+      t.string "login"
+      t.string "email"
+      t.string "language"
+      t.string "encrypted_password", limit: 128, default: "", null: false
+      t.string "password_salt", limit: 128, default: "", null: false
+      t.integer "sign_in_count", default: 0, null: false
+      t.integer "failed_attempts", default: 0, null: false
       t.datetime "last_request_at"
       t.datetime "current_sign_in_at"
       t.datetime "last_sign_in_at"
-      t.string   "current_sign_in_ip"
-      t.string   "last_sign_in_ip"
-      t.datetime "created_at",                                            null: false
-      t.datetime "updated_at",                                            null: false
-      t.integer  "creator_id"
-      t.integer  "updater_id"
-      t.text     "cached_tag_list"
-      t.string   "reset_password_token"
+      t.string "current_sign_in_ip"
+      t.string "last_sign_in_ip"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.integer "creator_id"
+      t.integer "updater_id"
+      t.text "cached_tag_list"
+      t.string "reset_password_token"
       t.datetime "reset_password_sent_at"
     end
 

--- a/lib/alchemy/devise.rb
+++ b/lib/alchemy/devise.rb
@@ -6,12 +6,12 @@ module Alchemy
   # === Default modules
   #
   #     [
-  #.      :database_authenticatable,
+  # .      :database_authenticatable,
   #       :trackable,
   #       :validatable,
   #       :timeoutable,
   #       :recoverable
-  #.    ]
+  # .    ]
   #
   # If you want to add additional modules into the Alchemy user class append
   # them to this collection in an initializer in your app.

--- a/lib/alchemy/devise/engine.rb
+++ b/lib/alchemy/devise/engine.rb
@@ -1,24 +1,24 @@
-require 'alchemy_cms'
-require 'devise'
+require "alchemy_cms"
+require "devise"
 
 module Alchemy
   module Devise
     class Engine < ::Rails::Engine
       isolate_namespace Alchemy
-      engine_name 'alchemy_devise'
+      engine_name "alchemy_devise"
 
       initializer "alchemy_devise.user_class", before: "alchemy.userstamp" do
         Alchemy.user_class_name = "Alchemy::User"
       end
 
-      initializer 'alchemy_devise.assets' do |app|
+      initializer "alchemy_devise.assets" do |app|
         app.config.assets.precompile += [
-          'alchemy-devise.css'
+          "alchemy-devise.css"
         ]
       end
 
       config.to_prepare do
-        require_relative '../../../app/controllers/alchemy/base_controller_extension.rb'
+        require_relative "../../../app/controllers/alchemy/base_controller_extension"
       end
     end
   end

--- a/lib/alchemy/devise/test_support/factories.rb
+++ b/lib/alchemy/devise/test_support/factories.rb
@@ -4,25 +4,25 @@ FactoryBot.define do
   factory :alchemy_user, class: Alchemy::User do
     sequence(:login) { |n| "john_#{n}.doe" }
     sequence(:email) { |n| "john_#{n}@doe.com" }
-    firstname { 'John' }
-    lastname { 'Doe' }
-    password { 's3cr3t' }
-    password_confirmation { 's3cr3t' }
+    firstname { "John" }
+    lastname { "Doe" }
+    password { "s3cr3t" }
+    password_confirmation { "s3cr3t" }
 
     factory :alchemy_admin_user do
-      alchemy_roles { 'admin' }
+      alchemy_roles { "admin" }
     end
 
     factory :alchemy_member_user do
-      alchemy_roles { 'member' }
+      alchemy_roles { "member" }
     end
 
     factory :alchemy_author_user do
-      alchemy_roles { 'author' }
+      alchemy_roles { "author" }
     end
 
     factory :alchemy_editor_user do
-      alchemy_roles { 'editor' }
+      alchemy_roles { "editor" }
     end
   end
 end

--- a/lib/generators/alchemy/devise/install/install_generator.rb
+++ b/lib/generators/alchemy/devise/install/install_generator.rb
@@ -3,18 +3,18 @@ module Alchemy
     module Generators
       class InstallGenerator < Rails::Generators::Base
         desc "Installs Alchemy Devise based authentication into your app."
-        source_root File.expand_path('templates', File.dirname(__FILE__))
+        source_root File.expand_path("templates", File.dirname(__FILE__))
 
         def copy_devise_config
-          template 'devise.rb.tt', 'config/initializers/devise.rb'
+          template "devise.rb.tt", "config/initializers/devise.rb"
         end
 
         def add_migrations
-          run 'bundle exec rake alchemy_devise:install:migrations'
+          run "bundle exec rake alchemy_devise:install:migrations"
         end
 
         def run_migrations
-          run 'bundle exec rake db:migrate'
+          run "bundle exec rake db:migrate"
         end
 
         def append_assets

--- a/spec/controllers/admin/user_sessions_controller_spec.rb
+++ b/spec/controllers/admin/user_sessions_controller_spec.rb
@@ -24,13 +24,13 @@ describe Alchemy::Admin::UserSessionsController do
     describe "#create" do
       context "with valid user" do
         let(:screen_size) { "1200x800" }
-        let(:user_params) { { login: user.login, password: "s3cr3t" } }
+        let(:user_params) { {login: user.login, password: "s3cr3t"} }
 
         before { user }
 
         context "without redirect path in session" do
           it "redirects to dashboard" do
-            post :create, params: { user: user_params }
+            post :create, params: {user: user_params}
             expect(response).to redirect_to(admin_dashboard_path)
           end
         end
@@ -38,14 +38,14 @@ describe Alchemy::Admin::UserSessionsController do
         context "with redirect path in session" do
           it "redirects to these params" do
             session[:redirect_path] = admin_users_path
-            post :create, params: { user: user_params }
+            post :create, params: {user: user_params}
             expect(response).to redirect_to(admin_users_path)
           end
         end
 
         context "without valid params" do
           it "renders login form" do
-            post :create, params: { user: { login: "" } }
+            post :create, params: {user: {login: ""}}
             is_expected.to render_template(:new)
           end
         end
@@ -56,7 +56,7 @@ describe Alchemy::Admin::UserSessionsController do
       before do
         allow(controller).to receive(:store_user_request_time)
         allow(controller).to receive(:all_signed_out?)
-                               .and_return(false)
+          .and_return(false)
         authorize_user(user)
       end
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,11 +1,11 @@
-require 'rails_helper'
+require "rails_helper"
 
 module Alchemy
   describe Admin::UsersController do
     routes { Alchemy::Engine.routes }
 
     let(:admin) { build_stubbed(:alchemy_admin_user) }
-    let(:user)  { build_stubbed(:alchemy_user) }
+    let(:user) { build_stubbed(:alchemy_user) }
 
     before do
       allow(controller).to receive_messages(store_user_request_time: true)
@@ -13,24 +13,24 @@ module Alchemy
       authorize_user(admin)
     end
 
-    describe '#index' do
-      let(:user) { create :alchemy_user}
+    describe "#index" do
+      let(:user) { create :alchemy_user }
 
-      context 'with matching search query' do
+      context "with matching search query" do
         it "lists all matching users" do
-          get :index, params: {q: { email_cont: user.email }}
+          get :index, params: {q: {email_cont: user.email}}
           expect(assigns(:users)).to include(user)
         end
       end
 
-      context 'with non-matching search query' do
+      context "with non-matching search query" do
         it "lists all matching users" do
-          get :index, params: {q: { email_cont: "Tarzan" }}
+          get :index, params: {q: {email_cont: "Tarzan"}}
           expect(assigns(:users)).not_to include(user)
         end
       end
 
-      context 'without search query' do
+      context "without search query" do
         it "lists all users" do
           get :index
           expect(assigns(:users)).to include(user)
@@ -38,7 +38,7 @@ module Alchemy
       end
     end
 
-    describe '#signup' do
+    describe "#signup" do
       context "with users present" do
         before { allow(User).to receive_messages(count: 1) }
 
@@ -49,7 +49,7 @@ module Alchemy
       end
     end
 
-    describe '#create' do
+    describe "#create" do
       before { ActionMailer::Base.deliveries.clear }
 
       around do |example|
@@ -61,7 +61,7 @@ module Alchemy
         expect(Alchemy::User.count).to eq(1)
       end
 
-      context 'while signup' do
+      context "while signup" do
         before { allow(User).to receive(:count).and_return(0) }
 
         it "sets the user role to admin." do
@@ -79,13 +79,13 @@ module Alchemy
 
       context "with send_credentials set to '1'" do
         it "should send an email notification" do
-          post :create, params: {user: attributes_for(:alchemy_user).merge(send_credentials: '1')}
+          post :create, params: {user: attributes_for(:alchemy_user).merge(send_credentials: "1")}
           expect(ActionMailer::Base.deliveries).not_to be_empty
         end
 
-        context 'with invalid user' do
+        context "with invalid user" do
           it "does not send an email notification" do
-            post :create, params: {user: {send_credentials: '1', email: ''}}
+            post :create, params: {user: {send_credentials: "1", email: ""}}
             expect(ActionMailer::Base.deliveries).to be_empty
           end
         end
@@ -106,7 +106,7 @@ module Alchemy
       end
     end
 
-    describe '#update' do
+    describe "#update" do
       before { ActionMailer::Base.deliveries.clear }
 
       around do |example|
@@ -116,9 +116,9 @@ module Alchemy
       context "with empty password passed" do
         it "should update the user" do
           params_hash = {
-            'firstname' => 'Johnny',
-            'password' => '',
-            'password_confirmation' => ''
+            "firstname" => "Johnny",
+            "password" => "",
+            "password_confirmation" => ""
           }
           expect(user)
             .to receive(:update_without_password)
@@ -131,9 +131,9 @@ module Alchemy
       context "with new password passed" do
         it "should update the user" do
           params_hash = {
-            'firstname' => 'Johnny',
-            'password' => 'newpassword',
-            'password_confirmation' => 'newpassword'
+            "firstname" => "Johnny",
+            "password" => "newpassword",
+            "password_confirmation" => "newpassword"
           }
           expect(user).to receive(:update).with(params_hash)
 
@@ -145,13 +145,13 @@ module Alchemy
         let(:user) { create(:alchemy_admin_user) }
 
         it "should send an email notification" do
-          post :update, params: {id: user.id, user: {send_credentials: '1'}}
+          post :update, params: {id: user.id, user: {send_credentials: "1"}}
           expect(ActionMailer::Base.deliveries).to_not be_empty
         end
 
-        context 'with invalid user' do
+        context "with invalid user" do
           it "does not send an email notification" do
-            post :update, params: {id: user.id, user: {send_credentials: '1', email: ''}}
+            post :update, params: {id: user.id, user: {send_credentials: "1", email: ""}}
             expect(ActionMailer::Base.deliveries).to be_empty
           end
         end
@@ -177,8 +177,8 @@ module Alchemy
         it "updates the user including role" do
           expect(user)
             .to receive(:update_without_password)
-            .with({'alchemy_roles' => ['Administrator']})
-          post :update, params: {id: user.id, user: {alchemy_roles: ['Administrator']}, format: :js}
+            .with({"alchemy_roles" => ["Administrator"]})
+          post :update, params: {id: user.id, user: {alchemy_roles: ["Administrator"]}, format: :js}
         end
       end
 
@@ -192,12 +192,12 @@ module Alchemy
 
         it "updates user without role" do
           expect(user).to receive(:update_without_password).with({})
-          post :update, params: {id: user.id, user: {alchemy_roles: ['Administrator']}, format: :js}
+          post :update, params: {id: user.id, user: {alchemy_roles: ["Administrator"]}, format: :js}
         end
       end
     end
 
-    describe '#destroy' do
+    describe "#destroy" do
       it "redirects to users list" do
         expect(user).to receive(:destroy).and_return(true)
         delete :destroy, params: {id: user.id}

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -1,8 +1,7 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe Alchemy::BaseController do
-
-  describe '#store_user_request_time' do
+  describe "#store_user_request_time" do
     context "user not logged in" do
       before { allow(controller).to receive(:alchemy_user_signed_in?).and_return(false) }
 
@@ -14,7 +13,7 @@ describe Alchemy::BaseController do
     context "user logged in" do
       before do
         allow(controller).to receive(:alchemy_user_signed_in?).and_return(true)
-        allow(controller).to receive(:current_alchemy_user).and_return(mock_model('User', store_request_time!: true))
+        allow(controller).to receive(:current_alchemy_user).and_return(mock_model("User", store_request_time!: true))
       end
 
       it "should not store the current request time" do
@@ -22,5 +21,4 @@ describe Alchemy::BaseController do
       end
     end
   end
-
 end

--- a/spec/features/admin/users_feature_spec.rb
+++ b/spec/features/admin/users_feature_spec.rb
@@ -1,26 +1,25 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Admin users feature." do
-
-  describe 'signup user' do
+  describe "signup user" do
     it "renders signup form" do
       visit admin_signup_path
 
-      expect(page).to have_content('Please signup to edit your Website.')
-      expect(page).to have_selector('.login_signup_box')
+      expect(page).to have_content("Please signup to edit your Website.")
+      expect(page).to have_selector(".login_signup_box")
     end
 
     it "does not render tag list input" do
       visit admin_signup_path
 
-      expect(page).not_to have_selector('.tag_list')
+      expect(page).not_to have_selector(".tag_list")
     end
   end
 
-  context 'logged in as admin' do
+  context "logged in as admin" do
     before { authorize_user(create(:alchemy_admin_user)) }
 
-    describe 'create new user' do
+    describe "create new user" do
       it "has send_credentials checkbox activated" do
         visit new_admin_user_path
 
@@ -52,7 +51,7 @@ describe "Admin users feature." do
       end
     end
 
-    describe 'edit existing user' do
+    describe "edit existing user" do
       let(:user) { create(:alchemy_author_user) }
 
       it "has send_credentials checkbox deactivated" do

--- a/spec/features/login_feature_spec.rb
+++ b/spec/features/login_feature_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Login: " do
   context "If user is present" do
     let!(:user) do
       Alchemy::User.create!(
-        login: 'admin',
-        email: 'admin@example.com',
-        password: 's3cr3t',
-        password_confirmation: 's3cr3t',
+        login: "admin",
+        email: "admin@example.com",
+        password: "s3cr3t",
+        password_confirmation: "s3cr3t",
         alchemy_roles: %w[admin]
       )
     end
@@ -20,16 +20,16 @@ describe "Login: " do
 
     context "with Alchemy configuration" do
       it "displays an login authentication field" do
-        visit '/admin/login'
-        expect(page).to have_field('user_login')
+        visit "/admin/login"
+        expect(page).to have_field("user_login")
       end
 
       it "works" do
-        visit '/admin/login'
-        fill_in 'user_login', with: user.login
-        fill_in 'user_password', with: user.password
-        click_button 'Login'
-        expect(page).to have_content('Welcome back admin')
+        visit "/admin/login"
+        fill_in "user_login", with: user.login
+        fill_in "user_password", with: user.password
+        click_button "Login"
+        expect(page).to have_content("Welcome back admin")
       end
     end
 
@@ -39,16 +39,16 @@ describe "Login: " do
       end
 
       it "displays an email authentication field" do
-        visit '/admin/login'
-        expect(page).to have_field('user_email')
+        visit "/admin/login"
+        expect(page).to have_field("user_email")
       end
 
       it "works" do
-        visit '/admin/login'
-        fill_in 'user_email', with: user.email
-        fill_in 'user_password', with: user.password
-        click_button 'Login'
-        expect(page).to have_content('Welcome back admin')
+        visit "/admin/login"
+        fill_in "user_email", with: user.email
+        fill_in "user_password", with: user.password
+        click_button "Login"
+        expect(page).to have_content("Welcome back admin")
       end
 
       after do

--- a/spec/features/password_reset_feature_spec.rb
+++ b/spec/features/password_reset_feature_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Password reset feature." do
   let(:user) { create(:alchemy_admin_user) }
@@ -6,17 +6,17 @@ describe "Password reset feature." do
   it "User can visit password reset form." do
     visit admin_new_password_path
 
-    expect(page).to have_content('Password reset')
+    expect(page).to have_content("Password reset")
   end
 
   it "User can request password reset." do
     visit admin_new_password_path
 
     fill_in :user_email, with: user.email
-    click_button 'Send reset instructions'
+    click_button "Send reset instructions"
 
     expect(page)
-      .to have_content('You will receive an email with instructions on how to reset your password in a few minutes.')
+      .to have_content("You will receive an email with instructions on how to reset your password in a few minutes.")
   end
 
   it "User can change password." do
@@ -24,13 +24,13 @@ describe "Password reset feature." do
       .to receive(:reset_password_by_token)
       .and_return(user)
 
-    visit admin_edit_password_path(id: user.id, reset_password_token: '1234')
+    visit admin_edit_password_path(id: user.id, reset_password_token: "1234")
 
-    fill_in :user_password, with: 'secret123'
-    fill_in :user_password_confirmation, with: 'secret123'
-    click_button 'Change password'
+    fill_in :user_password, with: "secret123"
+    fill_in :user_password_confirmation, with: "secret123"
+    click_button "Change password"
 
     expect(page)
-      .to have_content('Your password has been changed successfully.')
+      .to have_content("Your password has been changed successfully.")
   end
 end

--- a/spec/features/security_feature_spec.rb
+++ b/spec/features/security_feature_spec.rb
@@ -1,18 +1,18 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Security: " do
   context "If user is present" do
-    before { allow(Alchemy::User).to receive_messages(:count => 1) }
+    before { allow(Alchemy::User).to receive_messages(count: 1) }
 
     it "a visitor should not be able to signup" do
-      visit '/admin/signup'
-      within('.login_signup_box') { expect(page).not_to have_content('have to signup') }
+      visit "/admin/signup"
+      within(".login_signup_box") { expect(page).not_to have_content("have to signup") }
     end
 
     context "that is not logged in" do
       it "should see login form" do
-        visit '/admin/dashboard'
-        expect(current_path).to eq('/admin/login')
+        visit "/admin/dashboard"
+        expect(current_path).to eq("/admin/login")
       end
     end
   end

--- a/spec/libraries/ability_spec.rb
+++ b/spec/libraries/ability_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
-require 'cancan/matchers'
+require "rails_helper"
+require "cancan/matchers"
 
 describe Alchemy::Permissions do
   subject { ability }
@@ -17,7 +17,7 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:signup, Alchemy.user_class)
     end
 
-    context 'if no user is present' do
+    context "if no user is present" do
       before { expect(Alchemy::User).to receive(:count).and_return(0) }
 
       it "can create user" do
@@ -25,7 +25,7 @@ describe Alchemy::Permissions do
       end
     end
 
-    context 'if user is present' do
+    context "if user is present" do
       before { expect(Alchemy::User).to receive(:count).and_return(1) }
 
       it "cannot create user" do
@@ -35,7 +35,7 @@ describe Alchemy::Permissions do
   end
 
   context "A member" do
-    let(:user)         { build_stubbed(:alchemy_member_user) }
+    let(:user) { build_stubbed(:alchemy_member_user) }
     let(:another_user) { build_stubbed(:alchemy_member_user) }
 
     it "can only update its own user record" do
@@ -54,7 +54,7 @@ describe Alchemy::Permissions do
   end
 
   context "An author" do
-    let(:user)         { build_stubbed(:alchemy_author_user) }
+    let(:user) { build_stubbed(:alchemy_author_user) }
     let(:another_user) { build_stubbed(:alchemy_member_user) }
 
     it "can only update its own user record" do
@@ -69,7 +69,7 @@ describe Alchemy::Permissions do
   end
 
   context "An editor" do
-    let(:user)         { build_stubbed(:alchemy_editor_user) }
+    let(:user) { build_stubbed(:alchemy_editor_user) }
     let(:another_user) { build_stubbed(:alchemy_member_user) }
 
     it "can see all users" do

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -1,21 +1,20 @@
-require 'rails_helper'
+require "rails_helper"
 
 module Alchemy
   describe Notifications do
-
     context "when a member user was created" do
       let(:user) do
-        mock_model 'User',
-          alchemy_roles: %w(member),
-          email: 'jon@doe.com',
-          name: 'John Doe',
-          login: 'jon.doe'
+        mock_model "User",
+          alchemy_roles: %w[member],
+          email: "jon@doe.com",
+          name: "John Doe",
+          login: "jon.doe"
       end
       let(:mail) { Notifications.member_created(user) }
 
       it "delivers a mail to user" do
         expect(mail.to).to eq([user.email])
-        expect(mail.subject).to eq('Your user credentials')
+        expect(mail.subject).to eq("Your user credentials")
       end
 
       it "mail body includes users name" do
@@ -27,39 +26,39 @@ module Alchemy
       end
 
       it "mail body includes password instructions" do
-        expect(mail.body.raw_source).to match /#{Regexp.escape(admin_new_password_url(email: user.email, only_path: true))}/
+        expect(mail.body.raw_source).to match(/#{Regexp.escape(admin_new_password_url(email: user.email, only_path: true))}/)
       end
     end
 
     context "when an admin user was created" do
-      let(:user) { mock_model('User', alchemy_roles: %w(admin), email: 'jon@doe.com', name: 'John Doe', login: 'jon.doe') }
+      let(:user) { mock_model("User", alchemy_roles: %w[admin], email: "jon@doe.com", name: "John Doe", login: "jon.doe") }
       let(:mail) { Notifications.alchemy_user_created(user) }
 
       it "delivers a mail to user" do
         expect(mail.to).to eq([user.email])
-        expect(mail.subject).to eq('Your Alchemy Login')
+        expect(mail.subject).to eq("Your Alchemy Login")
       end
 
       it "mail body includes users login" do
-        expect(mail.body.raw_source).to match /#{user.login}/
+        expect(mail.body.raw_source).to match(/#{user.login}/)
       end
 
       it "mail body includes password instructions" do
-        expect(mail.body.raw_source).to match /#{Regexp.escape(admin_new_password_url(only_path: true))}/
+        expect(mail.body.raw_source).to match(/#{Regexp.escape(admin_new_password_url(only_path: true))}/)
       end
     end
 
-    describe '#reset_password_instructions' do
+    describe "#reset_password_instructions" do
       let(:user) do
-        mock_model 'User',
-          alchemy_roles: %w(member),
-          email: 'jon@doe.com',
-          name: 'John Doe',
-          login: 'jon.doe',
-          fullname: 'John Doe'
+        mock_model "User",
+          alchemy_roles: %w[member],
+          email: "jon@doe.com",
+          name: "John Doe",
+          login: "jon.doe",
+          fullname: "John Doe"
       end
 
-      let(:token) { '123456789' }
+      let(:token) { "123456789" }
 
       let(:mail) do
         Notifications.reset_password_instructions(user, token)
@@ -67,15 +66,15 @@ module Alchemy
 
       it "delivers a mail to user" do
         expect(mail.to).to eq([user.email])
-        expect(mail.subject).to eq('Reset password instructions')
+        expect(mail.subject).to eq("Reset password instructions")
       end
 
       it "mail body includes users name" do
-        expect(mail.body.raw_source).to match /#{user.name}/
+        expect(mail.body.raw_source).to match(/#{user.name}/)
       end
 
       it "mail body includes reset instructions" do
-        expect(mail.body.raw_source).to match /#{Regexp.escape(admin_edit_password_url(user, reset_password_token: token, only_path: true))}/
+        expect(mail.body.raw_source).to match(/#{Regexp.escape(admin_edit_password_url(user, reset_password_token: token, only_path: true))}/)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ module Alchemy
     describe ".ransack" do
       subject do
         User.ransack(
-          "email_or_login_or_firstname_or_lastname_cont" => query,
+          "email_or_login_or_firstname_or_lastname_cont" => query
         ).result
       end
 
@@ -97,28 +97,28 @@ module Alchemy
 
       it "delivers the admin welcome mail." do
         expect(Notifications).to receive(:alchemy_user_created)
-                                   .and_return(OpenStruct.new(deliver: true))
+          .and_return(OpenStruct.new(deliver: true))
 
         user.deliver_welcome_mail
       end
 
       context "of author user" do
-        before { user.alchemy_roles = %w(author) }
+        before { user.alchemy_roles = %w[author] }
 
         it "delivers the admin welcome mail." do
           expect(Notifications).to receive(:alchemy_user_created)
-                                     .and_return(OpenStruct.new(deliver: true))
+            .and_return(OpenStruct.new(deliver: true))
 
           user.deliver_welcome_mail
         end
       end
 
       context "of member user" do
-        before { user.alchemy_roles = %w(member) }
+        before { user.alchemy_roles = %w[member] }
 
         it "delivers the welcome mail." do
           expect(Notifications).to receive(:member_created)
-                                     .and_return(OpenStruct.new(deliver: true))
+            .and_return(OpenStruct.new(deliver: true))
 
           user.deliver_welcome_mail
         end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,7 @@ ActiveSupport::Deprecation.silenced = true
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
-  config.include Devise::TestHelpers, :type => :controller
+  config.include Devise::TestHelpers, type: :controller
   config.include Alchemy::Engine.routes.url_helpers
   config.include FactoryBot::Syntax::Methods
   config.include ActiveJob::TestHelper

--- a/spec/requests/admin/users_controller_request_spec.rb
+++ b/spec/requests/admin/users_controller_request_spec.rb
@@ -1,49 +1,48 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Alchemy::Admin::UsersController, type: :request do
   before do
     authorize_user create(:alchemy_admin_user)
   end
 
-  context 'with error happening while sending mail' do
+  context "with error happening while sending mail" do
     before do
-      allow_any_instance_of(Alchemy::Admin::BaseController).
-        to receive(:raise_exception?) { false }
-      allow_any_instance_of(Alchemy::User).
-        to receive(:deliver_welcome_mail) { raise(Net::SMTPAuthenticationError) }
+      allow_any_instance_of(Alchemy::Admin::BaseController)
+        .to receive(:raise_exception?) { false }
+      allow_any_instance_of(Alchemy::User)
+        .to receive(:deliver_welcome_mail) { raise(Net::SMTPAuthenticationError) }
     end
 
-    context 'on create' do
-      it 'does not raise DoubleRender error' do
+    context "on create" do
+      it "does not raise DoubleRender error" do
         expect {
-          post admin_users_path, params: {user: attributes_for(:alchemy_user).merge(send_credentials: '1')}
+          post admin_users_path, params: {user: attributes_for(:alchemy_user).merge(send_credentials: "1")}
         }.to_not raise_error
       end
     end
 
-    context 'on update' do
-      it 'does not raise DoubleRender error' do
-        user =  create(:alchemy_member_user)
+    context "on update" do
+      it "does not raise DoubleRender error" do
+        user = create(:alchemy_member_user)
         expect {
-          patch admin_user_path(user), params: {user: {send_credentials: '1'}}
+          patch admin_user_path(user), params: {user: {send_credentials: "1"}}
         }.to_not raise_error
       end
     end
   end
 
-  context 'with Alchemy.admin_path customised' do
+  context "with Alchemy.admin_path customised" do
     before(:all) do
-      Alchemy.admin_path = '/backend'
+      Alchemy.admin_path = "/backend"
       Rails.application.reload_routes!
     end
 
-    it 'uses the custom admin path' do
-      expect(admin_users_path).to eq('/backend/users')
+    it "uses the custom admin path" do
+      expect(admin_users_path).to eq("/backend/users")
     end
 
-
     after(:all) do
-      Alchemy.admin_path = '/admin'
+      Alchemy.admin_path = "/admin"
       Rails.application.reload_routes!
     end
   end

--- a/spec/routing/password_routing_spec.rb
+++ b/spec/routing/password_routing_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Password Routing" do
   routes { Alchemy::Engine.routes }

--- a/spec/routing/session_routing_spec.rb
+++ b/spec/routing/session_routing_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "Session Routing" do
   routes { Alchemy::Engine.routes }

--- a/spec/routing/user_routing_spec.rb
+++ b/spec/routing/user_routing_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "User Routing" do
   routes { Alchemy::Engine.routes }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-if ENV['TRAVIS']
+require "simplecov"
+if ENV["TRAVIS"]
   require "codeclimate-test-reporter"
 end
-SimpleCov.start 'rails' do
-  add_filter '/lib/alchemy/devise/version'
-  add_filter '/lib/generators'
+SimpleCov.start "rails" do
+  add_filter "/lib/alchemy/devise/version"
+  add_filter "/lib/generators"
 end
 
-require 'rspec/core'
+require "rspec/core"
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
Uses standard.rb as code linter over Rubocop. Standard uses Rubocop under the hood, but provides sane defaults and
removes the necessity to maintain Rubocop rules. We still configure Rubocop so that it uses the standard.yml rules, so that
your editor can use that to auto-format and lint the code in Alchemy.