### PR TITLE
Remove Alchemy 7.0 and 6.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
         alchemy_branch:
           - 6.0-stable
           - 6.1-stable
-          - main
         ruby:
           - "3.0"
           - "3.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         alchemy_branch:
-          - 6.0-stable
           - 6.1-stable
         ruby:
           - "3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,7 @@
 source "https://rubygems.org"
 
-alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "main")
+alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "6.1-stable")
 gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
-
-if alchemy_branch == "main"
-  gem "jsbundling-rails", "~> 1.1"
-end
 
 gem "rails", "~> 6.1.7"
 gem "listen", "~> 3.8"

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ namespace :alchemy do
           <<~SETUP
             bin/rake railties:install:migrations
             bin/rake db:drop db:create db:migrate
-            bin/rails g alchemy:install --force --auto-accept
+            bin/rails g alchemy:install --force --auto-accept --force-babel-config
             bin/rails g alchemy:devise:install --force
           SETUP
         )

--- a/Rakefile
+++ b/Rakefile
@@ -31,9 +31,6 @@ namespace :alchemy do
     desc "Prepares database for testing Alchemy"
     task :prepare do
       Dir.chdir("spec/dummy") do
-        if ENV["ALCHEMY_BRANCH"] == "main"
-          system("bin/rails javascript:install:esbuild") || exit($?.exitstatus)
-        end
         system(
           <<~SETUP
             bin/rake railties:install:migrations
@@ -43,11 +40,7 @@ namespace :alchemy do
           SETUP
         )
         exit($?.exitstatus) unless $?.success?
-        if ENV["ALCHEMY_BRANCH"] == "main"
-          system("bin/rails javascript:build") || exit($?.exitstatus)
-        else
-          system("bin/rails webpacker:compile") || exit($?.exitstatus)
-        end
+        system("bin/rails webpacker:compile") || exit($?.exitstatus)
       end
     end
   end

--- a/alchemy-devise.gemspec
+++ b/alchemy-devise.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "CHANGELOG.md", "README.md"]
 
-  s.add_dependency "alchemy_cms", [">= 6.0.0", "< 7"]
+  s.add_dependency "alchemy_cms", [">= 6.1.0", "< 7"]
   s.add_dependency "devise", [">= 4.7.1", "< 5"]
 
   s.add_development_dependency "capybara"

--- a/alchemy-devise.gemspec
+++ b/alchemy-devise.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "CHANGELOG.md", "README.md"]
 
-  s.add_dependency "alchemy_cms", [">= 6.0.0", "< 8"]
+  s.add_dependency "alchemy_cms", [">= 6.0.0", "< 7"]
   s.add_dependency "devise", [">= 4.7.1", "< 5"]
 
   s.add_development_dependency "capybara"


### PR DESCRIPTION
Alchemy 7 does not need any js build step
but Alchemy 6.1 still uses webpacker.
Since we already need patches for webpacker
to install correctly we will remove Alchemy 7
support from this version and release a 7.0
instead that only supports Alchemy 7 and above.

We will add Alchemy 7.0 support in a separate PR #173 