### PR TITLE
test: Fix admin users feature spec

### DIFF
--- a/spec/features/admin/users_feature_spec.rb
+++ b/spec/features/admin/users_feature_spec.rb
@@ -30,10 +30,14 @@ describe "Admin users feature." do
     describe "users list" do
       let!(:users) { create_list(:alchemy_user, 2) }
 
-      it "lists existing users" do
+      it "lists existing users", :aggregate_failures do
         visit admin_users_path
 
-        expect(page).to have_selector "table#user_list"
+        within "table.list" do
+          users.each do |user|
+            expect(page).to have_text user.email
+          end
+        end
       end
 
       it "is searchable" do


### PR DESCRIPTION
In Alchemy 7.3 the table does not have an id anymore.