### PR TITLE
Extend test matrix

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   brakeman-scan:
     name: Brakeman Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   RSpec:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +106,7 @@ jobs:
           path: spec/dummy/tmp/screenshots
 
   Lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ALCHEMY_BRANCH: 7.3-stable
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,33 @@ jobs:
       fail-fast: false
       matrix:
         alchemy_branch:
-          - "7.0-stable"
           - "7.1-stable"
           - "7.2-stable"
           - "7.3-stable"
+          - "7.4-stable"
         ruby:
-          - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
         rails:
-          - "7.0"
           - "7.1"
+          - "7.2"
         database:
           - mysql
           - postgresql
+          - sqlite
+        exclude:
+          - alchemy_branch: "7.1-stable"
+            rails: "7.2"
+          - alchemy_branch: "7.2-stable"
+            rails: "7.2"
+          - alchemy_branch: "7.1-stable"
+            ruby: "3.4"
+          - alchemy_branch: "7.2-stable"
+            ruby: "3.4"
+          - rails: "7.1"
+            ruby: "3.4"
+
     env:
       DB: ${{ matrix.database }}
       DB_USER: alchemy_user

--- a/alchemy-devise.gemspec
+++ b/alchemy-devise.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "CHANGELOG.md", "README.md"]
 
-  s.add_dependency "alchemy_cms", [">= 7.0", "<= 8.1"]
+  s.add_dependency "alchemy_cms", ["~> 7.0"]
   s.add_dependency "devise", ["~> 4.9"]
 
   s.add_development_dependency "capybara"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,8 +27,6 @@ Capybara.default_selector = :css
 Capybara.ignore_hidden_elements = false
 ActiveJob::Base.queue_adapter = :test
 
-ActiveSupport::Deprecation.silenced = true
-
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true


### PR DESCRIPTION
This adds Rails 7.2 and 8, as well as Alchemy 7.4 and main, and sqlite to the test matrix.

We exclude some impossible combos.