### PR TITLE
Don't render link when user login is nil

### DIFF
--- a/app/views/alchemy/admin/users/_resource_table.html.erb
+++ b/app/views/alchemy/admin/users/_resource_table.html.erb
@@ -3,7 +3,7 @@
     <%= render_icon(:user, style: user.logged_in? ? "solid" : "regular") %>
   <% end %>
   <% table.column :login, sortable: true do |user| %>
-    <% if can?(:edit, user) %>
+    <% if can?(:edit, user) && user.login %>
       <%= link_to_dialog user.login,
         alchemy.edit_admin_user_path(user), {
           title: Alchemy.t(:edit_user),


### PR DESCRIPTION
When user login is nil, Rails renders the URL as link text instead. To avoid this, the link is only rendered when user.login is present.