### PR TITLE
feat: Add timezone to users

### DIFF
--- a/app/models/alchemy/user.rb
+++ b/app/models/alchemy/user.rb
@@ -14,7 +14,8 @@ module Alchemy
       :password,
       :password_confirmation,
       :send_credentials,
-      :tag_list
+      :tag_list,
+      :timezone
     ]
 
     devise(*Alchemy::Devise.config.devise_modules)

--- a/app/views/alchemy/admin/users/_fields.html.erb
+++ b/app/views/alchemy/admin/users/_fields.html.erb
@@ -10,6 +10,12 @@
 <% end %>
 <%= f.input :password, required: while_signup?, input_html: {autocomplete: "new-password"} %>
 <%= f.input :password_confirmation, required: while_signup?, input_html: {autocomplete: "new-password"} %>
+<%= f.input :timezone,
+  collection: ActiveSupport::TimeZone.all, label_method: :to_s, value_method: :name,
+  input_html: {
+    is: "alchemy-select",
+    data: {allow_clear: true}
+  } %>
 <% if can_update_role? %>
   <%= f.input :alchemy_roles,
     collection: @user_roles,

--- a/app/views/alchemy/admin/users/_resource_table.html.erb
+++ b/app/views/alchemy/admin/users/_resource_table.html.erb
@@ -8,7 +8,7 @@
         alchemy.edit_admin_user_path(user), {
           title: Alchemy.t(:edit_user),
           overflow: true,
-          size: "430x500"
+          size: "430x530"
         },
         title: Alchemy.t(:edit_user) %>
     <% else %>
@@ -28,5 +28,5 @@
     <%= user.human_roles_string %>
   <% end %>
   <% table.delete_button tooltip: Alchemy.t(:delete_user), confirm_message: Alchemy.t(:confirm_to_delete_user) %>
-  <% table.edit_button tooltip: Alchemy.t(:edit_user), dialog_size: "430x500" %>
+  <% table.edit_button tooltip: Alchemy.t(:edit_user), dialog_size: "430x530" %>
 <% end %>

--- a/app/views/alchemy/admin/users/index.html.erb
+++ b/app/views/alchemy/admin/users/index.html.erb
@@ -12,7 +12,7 @@
     tooltip_placement: "top-start",
     dialog_options: {
       title: Alchemy.t(:create_user),
-      size: "430x500"
+      size: "430x530"
     },
     if_permitted_to: [:create, Alchemy::User]
   ) %>

--- a/db/migrate/20260410115756_add_timezone_to_alchemy_users.rb
+++ b/db/migrate/20260410115756_add_timezone_to_alchemy_users.rb
@@ -1,0 +1,6 @@
+class AddTimezoneToAlchemyUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :alchemy_users, :timezone, :string, if_not_exists: true,
+      comment: "The timezone of the user, used for displaying dates in the user's timezone"
+  end
+end

--- a/spec/features/admin/users_feature_spec.rb
+++ b/spec/features/admin/users_feature_spec.rb
@@ -129,6 +129,19 @@ RSpec.describe "Admin users feature." do
       end
 
       it_behaves_like "allowing to set users language"
+
+      it "can set users timezone" do
+        subject
+
+        within "form.alchemy[action*='/admin/users']" do
+          expect(page).to have_select "Timezone"
+          select "Berlin", from: "Timezone"
+          click_button "Save"
+        end
+
+        expect(page).to have_content Alchemy.t("User updated", name: user.name)
+        expect(user.reload.timezone).to eq "Berlin"
+      end
     end
   end
 end


### PR DESCRIPTION
Allows users to set a preferred timezone, so Alchemy can display time values in the timezone of the user.