### PR TITLE
fix(User Form): Disable auto_submit on LocaleSelect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "8.2-stable")
-gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
+# alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "8.2-stable")
+gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "locale-select-auto-submit-option"
 
 rails_version = ENV.fetch("RAILS_VERSION", "8.0")
 gem "rails", "~> #{rails_version}.0"

--- a/app/views/alchemy/admin/users/_fields.html.erb
+++ b/app/views/alchemy/admin/users/_fields.html.erb
@@ -5,7 +5,7 @@
 <% if Alchemy::I18n.available_locales.many? %>
   <div class="input select">
     <%= f.label(:language) %>
-    <%= render Alchemy::Admin::LocaleSelect.new(f.field_name(:language)) %>
+    <%= render Alchemy::Admin::LocaleSelect.new(f.field_name(:language), auto_submit: false) %>
   </div>
 <% end %>
 <%= f.input :password, required: while_signup?, input_html: {autocomplete: "new-password"} %>


### PR DESCRIPTION
The default behavior of LocaleSelect is to auto submit the form. We do not want this for the user edit form.

~~**Needs https://github.com/AlchemyCMS/alchemy_cms/pull/3835**~~