### PR TITLE
Prevent AlchemyCMS v8.2 deprecation warnings

### DIFF
--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  Alchemy.register_ability(Alchemy::Devise::Ability)
+  Alchemy.config.abilities.add("Alchemy::Devise::Ability")
 
   Alchemy::Modules.register_module({
     name: "users",

--- a/lib/alchemy/devise/engine.rb
+++ b/lib/alchemy/devise/engine.rb
@@ -11,7 +11,7 @@ module Alchemy
       engine_name "alchemy_devise"
 
       initializer "alchemy_devise.user_class", before: "alchemy.userstamp" do
-        Alchemy.user_class_name = "Alchemy::User"
+        Alchemy.config.user_class = "Alchemy::User"
       end
 
       initializer "alchemy_devise.assets" do |app|


### PR DESCRIPTION
register_ability and user_class_name methods are deprecated and are now part of the config object.