### PR TITLE
chore: Update specs for Alchemy 8.4/main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,22 @@ on:
 
 jobs:
   RSpec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         alchemy_branch:
-          - "8.3-stable"
+          - main
         ruby:
-          - "3.3"
           - "3.4"
           - "4.0"
         rails:
-          - "7.2"
           - "8.0"
           - "8.1"
         database:
           - mysql
           - postgresql
           - sqlite
-
     env:
       DB: ${{ matrix.database }}
       DB_USER: alchemy_user
@@ -101,7 +98,7 @@ jobs:
           path: spec/dummy/tmp/screenshots
 
   Lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "8.3-stable")
+alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "main")
 gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
 
 rails_version = ENV.fetch("RAILS_VERSION", "8.0")

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -132,7 +132,7 @@ module Alchemy
             .to receive(:update_without_password)
             .with(ActionController::Parameters.new(params_hash).permit!).and_return(true)
 
-          post :update, params: {id: user.id, user: params_hash, format: :js}
+          post :update, params: {id: user.id, user: params_hash, format: :turbo_stream}
         end
       end
 
@@ -145,7 +145,7 @@ module Alchemy
           }
           expect(user).to receive(:update).with(ActionController::Parameters.new(params_hash).permit!)
 
-          post :update, params: {id: user.id, user: params_hash, format: :js}
+          post :update, params: {id: user.id, user: params_hash, format: :turbo_stream}
         end
       end
 
@@ -190,7 +190,7 @@ module Alchemy
           expect(user)
             .to receive(:update_without_password)
             .with(ActionController::Parameters.new({"alchemy_roles" => ["Administrator"]}).permit!)
-          post :update, params: {id: user.id, user: {alchemy_roles: ["Administrator"]}, format: :js}
+          post :update, params: {id: user.id, user: {alchemy_roles: ["Administrator"]}, format: :turbo_stream}
         end
       end
 
@@ -208,7 +208,7 @@ module Alchemy
 
         it "updates user without role" do
           expect(user).to receive(:update_without_password).with(ActionController::Parameters.new.permit!)
-          post :update, params: {id: user.id, user: {alchemy_roles: ["Administrator"]}, format: :js}
+          post :update, params: {id: user.id, user: {alchemy_roles: ["Administrator"]}, format: :turbo_stream}
         end
       end
     end

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -28,10 +28,12 @@ Alchemy.configure do |config|
   #
   #   show_root [Boolean] # Show language root page in sitemap?
   #   show_flag [Boolean] # Enables the Checkbox in Page#update overlay. So your customer can set the visibility of pages in the sitemap.
+  #   max_age [Integer]   # How long the sitemap is cached, in seconds. Set to 0 to disable sitemap caching.
   #
   # config.sitemap.tap do |sitemap|
   #   sitemap.show_root = true
   #   sitemap.show_flag = false
+  #   sitemap.max_age = 3600
   # end
 
   # === Default items per page in admin views
@@ -179,12 +181,6 @@ Alchemy.configure do |config|
   #
   # Values for the link target selectbox inside the page link overlay.
   # The value gets attached as a data-link-target attribute to the link.
-  #
-  # == Example:
-  #
-  # Open all links set to overlay inside an jQuery UI Dialog Window.
-  #
-  #   jQuery(a[data-link-target="overlay"]).dialog();
   #
   # config.link_target_options = ["blank"]
 

--- a/spec/libraries/ability_spec.rb
+++ b/spec/libraries/ability_spec.rb
@@ -10,18 +10,18 @@ describe Alchemy::Permissions do
     let(:user) { nil }
 
     it "can not see any user records" do
-      is_expected.not_to be_able_to(:read, Alchemy.user_class)
+      is_expected.not_to be_able_to(:read, Alchemy.config.user_class)
     end
 
     it "can signup user" do
-      is_expected.to be_able_to(:signup, Alchemy.user_class)
+      is_expected.to be_able_to(:signup, Alchemy.config.user_class)
     end
 
     context "if no user is present" do
       before { expect(Alchemy::User).to receive(:count).and_return(0) }
 
       it "can create user" do
-        is_expected.to be_able_to(:create, Alchemy.user_class)
+        is_expected.to be_able_to(:create, Alchemy.config.user_class)
       end
     end
 
@@ -29,7 +29,7 @@ describe Alchemy::Permissions do
       before { expect(Alchemy::User).to receive(:count).and_return(1) }
 
       it "cannot create user" do
-        is_expected.to_not be_able_to(:create, Alchemy.user_class)
+        is_expected.to_not be_able_to(:create, Alchemy.config.user_class)
       end
     end
   end
@@ -49,7 +49,7 @@ describe Alchemy::Permissions do
     end
 
     it "cannot see other user records" do
-      is_expected.to_not be_able_to(:index, Alchemy.user_class)
+      is_expected.to_not be_able_to(:index, Alchemy.config.user_class)
     end
   end
 
@@ -73,7 +73,7 @@ describe Alchemy::Permissions do
     let(:another_user) { build_stubbed(:alchemy_member_user) }
 
     it "can see all users" do
-      is_expected.to be_able_to(:read, Alchemy.user_class)
+      is_expected.to be_able_to(:read, Alchemy.config.user_class)
     end
 
     it "can only update its own user record" do
@@ -86,7 +86,7 @@ describe Alchemy::Permissions do
     let(:user) { build_stubbed(:alchemy_admin_user) }
 
     it "can manage users" do
-      is_expected.to be_able_to(:manage, Alchemy.user_class)
+      is_expected.to be_able_to(:manage, Alchemy.config.user_class)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -123,7 +123,7 @@ module Alchemy
 
       it "delivers the admin welcome mail." do
         expect(Notifications).to receive(:alchemy_user_created)
-          .and_return(OpenStruct.new(deliver: true))
+          .and_return(double(deliver_later: true))
 
         user.deliver_welcome_mail
       end
@@ -133,7 +133,7 @@ module Alchemy
 
         it "delivers the admin welcome mail." do
           expect(Notifications).to receive(:alchemy_user_created)
-            .and_return(OpenStruct.new(deliver: true))
+            .and_return(double(deliver_later: true))
 
           user.deliver_welcome_mail
         end
@@ -144,7 +144,7 @@ module Alchemy
 
         it "delivers the welcome mail." do
           expect(Notifications).to receive(:member_created)
-            .and_return(OpenStruct.new(deliver: true))
+            .and_return(double(deliver_later: true))
 
           user.deliver_welcome_mail
         end


### PR DESCRIPTION
Alchemy now uses Turbo frames to update dialogs instead of rails-ujs. The code is backwards compatible, but the specs need to adopt. Also fixes some deprecation warnings. Solved by updating the dummy app to Alchemy 8.4