### PR TITLE
feat: Use `Alchemy::UserMethods` module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       ALCHEMY_BRANCH: ${{ matrix.alchemy_branch }}
     services:
       postgres:
-        image: postgres:11
+        image: postgres:latest
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/Rakefile
+++ b/Rakefile
@@ -33,10 +33,10 @@ namespace :alchemy do
       Dir.chdir("spec/dummy") do
         system(
           <<~SETUP
-            bin/rake railties:install:migrations
-            bin/rake db:drop db:create db:migrate
-            bin/rails g alchemy:install --force --auto-accept --force-babel-config
-            bin/rails g alchemy:devise:install --force
+            bin/rake railties:install:migrations \
+            && bin/rake db:drop db:create db:migrate \
+            && bin/rails g alchemy:install --force --auto-accept --force-babel-config \
+            && bin/rails g alchemy:devise:install --force
           SETUP
         )
         exit($?.exitstatus) unless $?.success?

--- a/app/controllers/alchemy/admin/users_controller.rb
+++ b/app/controllers/alchemy/admin/users_controller.rb
@@ -69,7 +69,7 @@ module Alchemy
       def set_roles
         if can_update_role?
           @user_roles = User::ROLES.map do |role|
-            [User.human_rolename(role), role]
+            [User.human_alchemy_rolename(role), role]
           end
         end
       end

--- a/app/models/alchemy/devise/ability.rb
+++ b/app/models/alchemy/devise/ability.rb
@@ -26,19 +26,19 @@ module Alchemy
       private
 
       def member?
-        @user.try(:has_role?, :member)
+        @user.try(:has_alchemy_role?, :member)
       end
 
       def author?
-        @user.try(:has_role?, :author)
+        @user.try(:has_alchemy_role?, :author)
       end
 
       def editor?
-        @user.try(:has_role?, :editor)
+        @user.try(:has_alchemy_role?, :editor)
       end
 
       def admin?
-        @user.try(:has_role?, :admin)
+        @user.try(:has_alchemy_role?, :admin)
       end
     end
   end

--- a/app/models/alchemy/user.rb
+++ b/app/models/alchemy/user.rb
@@ -21,18 +21,19 @@ module Alchemy
     devise(*Alchemy::Devise.config.devise_modules)
 
     include Alchemy::Taggable
+    include Alchemy::UserMethods
 
     attr_accessor :send_credentials
 
     has_many :folded_pages
 
     validates :login, uniqueness: {case_sensitive: false}, presence: :login_required?
-    validates_presence_of :alchemy_roles
 
-    # Unlock all locked pages before destroy.
-    before_destroy :unlock_pages!
+    scope :admins, -> {
+      Alchemy::Deprecation.warn("#{name}.admins is deprecated. Please use #{name}.alchemy_admins instead.")
+      alchemy_admins
+    }
 
-    scope :admins, -> { where(arel_table[:alchemy_roles].matches("%admin%")) }
     scope :logged_in, -> { where("last_request_at > ?", logged_in_timeout.seconds.ago) }
     scope :logged_out, -> { where("last_request_at is NULL or last_request_at <= ?", logged_in_timeout.seconds.ago) }
 
@@ -61,9 +62,8 @@ module Alchemy
         ]
       end
 
-      def human_rolename(role)
-        Alchemy.t("user_roles.#{role}")
-      end
+      deprecate human_rolename: :human_alchemy_rolename, deprecator: Alchemy::Deprecation
+      alias_method :human_rolename, :human_alchemy_rolename
 
       def logged_in_timeout
         Alchemy.config.get(:auto_logout_time).minutes.to_i
@@ -73,53 +73,26 @@ module Alchemy
     def role_symbols
       alchemy_roles.map(&:to_sym)
     end
+    deprecate :role_symbols, deprecator: Alchemy::Deprecation
 
     def role
       alchemy_roles.first
     end
-
-    def alchemy_roles
-      read_attribute(:alchemy_roles).split(" ")
-    end
-
-    def alchemy_roles=(roles_string)
-      if roles_string.is_a? Array
-        write_attribute(:alchemy_roles, roles_string.join(" "))
-      elsif roles_string.is_a? String
-        write_attribute(:alchemy_roles, roles_string)
-      end
-    end
+    deprecate :role, deprecator: Alchemy::Deprecation
 
     def add_role(role)
       self.alchemy_roles = alchemy_roles.push(role.to_s).uniq
     end
+    deprecate add_role: :"alchemy_roles=", deprecator: Alchemy::Deprecation
 
-    # Returns true if the user ahs admin role
-    def is_admin?
-      has_role? "admin"
-    end
+    alias_method :is_admin?, :alchemy_admin?
+    deprecate is_admin?: :alchemy_admin?, deprecator: Alchemy::Deprecation
 
-    alias_method :admin?, :is_admin?
+    alias_method :has_role?, :has_alchemy_role?
+    deprecate has_role?: :has_alchemy_role?, deprecator: Alchemy::Deprecation
 
-    # Returns true if the user has the given role.
-    def has_role?(role)
-      alchemy_roles.include? role.to_s
-    end
-
-    # Calls unlock on all locked pages
-    def unlock_pages!
-      pages_locked_by_me.map(&:unlock!)
-    end
-
-    # Returns all pages locked by user.
-    #
-    # A page gets locked, if the user requests to edit the page.
-    #
-    def pages_locked_by_me
-      Page.locked_by(self).order(:updated_at)
-    end
-
-    alias_method :locked_pages, :pages_locked_by_me
+    alias_method :human_roles_string, :human_alchemy_roles
+    deprecate human_roles_string: :human_alchemy_roles, deprecator: Alchemy::Deprecation
 
     # Returns the firstname and lastname as a string
     #
@@ -160,11 +133,8 @@ module Alchemy
       !logged_in?
     end
 
-    def human_roles_string
-      alchemy_roles.map do |role|
-        self.class.human_rolename(role)
-      end.to_sentence
-    end
+    alias_method :pages_locked_by_me, :locked_pages
+    deprecate pages_locked_by_me: :locked_pages, deprecator: Alchemy::Deprecation
 
     def store_request_time!
       update_column(:last_request_at, Time.now)
@@ -173,7 +143,7 @@ module Alchemy
     # Delivers a welcome mail depending from user's role.
     #
     def deliver_welcome_mail
-      if has_role?("author") || has_role?("editor") || has_role?("admin")
+      if has_alchemy_role?("author") || has_alchemy_role?("editor") || has_alchemy_role?("admin")
         Notifications.alchemy_user_created(self).deliver_later
       else
         Notifications.member_created(self).deliver_later

--- a/app/views/alchemy/admin/users/_resource_table.html.erb
+++ b/app/views/alchemy/admin/users/_resource_table.html.erb
@@ -25,7 +25,7 @@
     <%= user.last_sign_in_at.present? ? l(user.last_sign_in_at, format: :"alchemy.default") : Alchemy.t(:unknown) %>
   <% end %>
   <% table.column :role, header: Alchemy::User.human_attribute_name(:alchemy_roles) do |user| %>
-    <%= user.human_roles_string %>
+    <%= user.human_alchemy_roles %>
   <% end %>
   <% table.delete_button tooltip: Alchemy.t(:delete_user), confirm_message: Alchemy.t(:confirm_to_delete_user) %>
   <% table.edit_button tooltip: Alchemy.t(:edit_user), dialog_size: "460x530" %>

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -179,8 +179,11 @@ Alchemy.configure do |config|
 
   # === Link Target Options
   #
-  # Values for the link target selectbox inside the page link overlay.
-  # The value gets attached as a data-link-target attribute to the link.
+  # Values for the link target selectbox inside the link dialog.
+  #
+  # Each value is stored with a leading underscore, so that it can be used as
+  # the link's `target` attribute right away: `blank` is stored as `_blank` and
+  # rendered as `target="_blank"`.
   #
   # config.link_target_options = ["blank"]
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -107,14 +107,18 @@ module Alchemy
 
       describe ".admins" do
         it "should only return users with admin role" do
-          expect(User.admins).to include(user)
+          Alchemy::Deprecation.silence do
+            expect(User.admins).to include(user)
+          end
         end
       end
     end
 
     describe ".human_rolename" do
       it "return a translated role name" do
-        expect(User.human_rolename("member")).to eq("Member")
+        Alchemy::Deprecation.silence do
+          expect(User.human_rolename("member")).to eq("Member")
+        end
       end
     end
 
@@ -154,17 +158,27 @@ module Alchemy
     describe "#human_roles_string" do
       it "should return a humanized roles string." do
         user.alchemy_roles = ["member", "admin"]
-        expect(user.human_roles_string).to eq("Member and Administrator")
+        Alchemy::Deprecation.silence do
+          expect(user.human_roles_string).to eq("Member and Administrator")
+        end
       end
     end
 
     describe "#role_symbols" do
       it "should return an array of user role symbols" do
-        expect(user.role_symbols).to eq([:member])
+        Alchemy::Deprecation.silence do
+          expect(user.role_symbols).to eq([:member])
+        end
       end
     end
 
     describe "#has_role?" do
+      around do |example|
+        Alchemy::Deprecation.silence do
+          example.run
+        end
+      end
+
       context "with given role" do
         it "should return true." do
           expect(user.has_role?("member")).to be_truthy
@@ -185,6 +199,12 @@ module Alchemy
     end
 
     describe "#role" do
+      around do |example|
+        Alchemy::Deprecation.silence do
+          example.run
+        end
+      end
+
       context "when user doesn't have any roles" do
         before { user.alchemy_roles = [] }
 
@@ -226,6 +246,12 @@ module Alchemy
     end
 
     describe "#add_role" do
+      around do |example|
+        Alchemy::Deprecation.silence do
+          example.run
+        end
+      end
+
       it "should add the given role to roles array" do
         user.add_role "admin"
         expect(user.alchemy_roles).to eq(["member", "admin"])
@@ -312,7 +338,9 @@ module Alchemy
       it "should return all pages that are locked by user" do
         user.save!
         page.lock_to!(user)
-        expect(user.locked_pages).to include(page)
+        Alchemy::Deprecation.silence do
+          expect(user.locked_pages).to include(page)
+        end
       end
     end
 
@@ -325,15 +353,18 @@ module Alchemy
       end
 
       it "should unlock all users lockes pages" do
-        user.unlock_pages!
-        expect(user.locked_pages).to be_empty
+        expect {
+          user.unlock_pages!
+        }.to change { user.locked_pages.count }.from(1).to(0)
       end
     end
 
     describe "#is_admin?" do
       it "should return true if the user has admin role" do
         user.alchemy_roles = "admin"
-        expect(user.is_admin?).to be_truthy
+        Alchemy::Deprecation.silence do
+          expect(user.is_admin?).to be_truthy
+        end
       end
     end
 


### PR DESCRIPTION
Alchemy 8.4 ships a shared module for `alchemy_roles` related methods. Using them over our custom methods. Deprecates a lot of unprefixed method names, since Alchemy provides conflict free ones.